### PR TITLE
losen requirements about service token provider args

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -48,7 +48,6 @@ func (p *PlanetScaleProvider) ConfigValidators(context.Context) []provider.Confi
 	return []provider.ConfigValidator{
 		providervalidator.Conflicting(path.MatchRoot("access_token"), path.MatchRoot("service_token")),
 		providervalidator.Conflicting(path.MatchRoot("access_token"), path.MatchRoot("service_token_name")),
-		providervalidator.RequiredTogether(path.MatchRoot("service_token"), path.MatchRoot("service_token_name")),
 	}
 }
 


### PR DESCRIPTION
When provided as env-vars, it's fine to have just one of then specified at a time in the config fields.