### PR TITLE
fix: handle 404s during Read() correctly

### DIFF
--- a/.github/workflows/test-extensive.yml
+++ b/.github/workflows/test-extensive.yml
@@ -28,8 +28,6 @@ jobs:
       - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
         with:
           go-version-file: 'go.mod'
-          cache: true
-      - run: go mod download
       - run: go build -v .
       - name: Run linters
         uses: golangci/golangci-lint-action@639cd343e1d3b897ff35927a75193d57cfcba299 # v3.6.0
@@ -45,27 +43,29 @@ jobs:
       fail-fast: false
       matrix:
         terraform:
-          - '1.0.*'
-          - '1.1.*'
-          - '1.2.*'
-          - '1.3.*'
-          - '1.4.*'
-          - '1.5.*'
+          # TODO: only test one for now since we are creating and destroying actual
+          # resources. Decide which versions to support when we are closer to a supported
+          # release.
+          # - '1.0.*'
+          # - '1.1.*'
+          # - '1.2.*'
+          # - '1.3.*'
+          # - '1.4.*'
+          # - '1.5.*'
           - '1.6.*'
     steps:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
       - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
         with:
           go-version-file: 'go.mod'
-          cache: true
       - uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
           terraform_version: ${{ matrix.terraform }}
           terraform_wrapper: false
-      - run: go mod download
-      - run: go test -v -cover ./internal/provider/
+      - run: make testacc
         env:
-          PLANETSCALE_SERVICE_TOKEN_NAME: ${{ secrets.PLANETSCALE_SERVICE_TOKEN_NAME }}
-          PLANETSCALE_SERVICE_TOKEN: ${{ secrets.PLANETSCALE_SERVICE_TOKEN }}
-          TF_ACC: "1"
+          # TODO: switch back to service-tokens when we can use them to run the fulll acctest suite
+          # PLANETSCALE_SERVICE_TOKEN_NAME: ${{ secrets.PLANETSCALE_SERVICE_TOKEN_NAME }}
+          # PLANETSCALE_SERVICE_TOKEN: ${{ secrets.PLANETSCALE_SERVICE_TOKEN }}
+          PLANETSCALE_ACCESS_TOKEN: ${{ secrets.PLANETSCALE_ACCESS_TOKEN }}
         timeout-minutes: 10

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,8 +21,6 @@ jobs:
       - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
         with:
           go-version-file: 'go.mod'
-          cache: true
-      - run: go mod download
       - run: go build -v .
       - name: Run linters
         uses: golangci/golangci-lint-action@639cd343e1d3b897ff35927a75193d57cfcba299 # v3.6.0
@@ -30,14 +28,13 @@ jobs:
           version: latest
 
   generate:
-    name: generate
+    name: generate diff test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
       - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
         with:
           go-version-file: 'go.mod'
-          cache: true
       - uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
           terraform_version: 1.6.1
@@ -57,23 +54,24 @@ jobs:
       fail-fast: false
       matrix:
         terraform:
-          - '1.0.*'
-          - '1.1.*'
-          - '1.2.*'
-          - '1.3.*'
-          - '1.4.*'
-          - '1.5.*'
+          # TODO: only test one for now since we are creating and destroying actual
+          # resources. Decide which versions to support when we are closer to a supported
+          # release.
+          # - '1.0.*'
+          # - '1.1.*'
+          # - '1.2.*'
+          # - '1.3.*'
+          # - '1.4.*'
+          # - '1.5.*'
           - '1.6.*'
     steps:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
       - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
         with:
           go-version-file: 'go.mod'
-          cache: true
       - uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
           terraform_version: ${{ matrix.terraform }}
           terraform_wrapper: false
-      - run: go mod download
       - run: go test -cover ./...
         timeout-minutes: 10

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ website/vendor
 *.winfile eol=crlf
 
 .env
+.envrc
+terraform-provider-planetscale

--- a/docs/data-sources/password.md
+++ b/docs/data-sources/password.md
@@ -31,7 +31,7 @@ output "password" {
 ### Required
 
 - `branch` (String) The branch this password belongs to..
-- `database` (String) The datanase this branch password belongs to.
+- `database` (String) The database this branch password belongs to.
 - `id` (String) The ID for the password.
 - `organization` (String) The organization this database branch password belongs to.
 

--- a/docs/data-sources/passwords.md
+++ b/docs/data-sources/passwords.md
@@ -50,7 +50,7 @@ Read-Only:
 - `actor` (Attributes) The actor that created this branch. (see [below for nested schema](#nestedatt--passwords--actor))
 - `branch` (String) The branch this password belongs to..
 - `created_at` (String) When the password was created.
-- `database` (String) The datanase this branch password belongs to.
+- `database` (String) The database this branch password belongs to.
 - `database_branch` (Attributes) The branch this password is allowed to access. (see [below for nested schema](#nestedatt--passwords--database_branch))
 - `deleted_at` (String) When the password was deleted.
 - `expires_at` (String) When the password will expire.

--- a/docs/resources/password.md
+++ b/docs/resources/password.md
@@ -32,7 +32,7 @@ output "password" {
 ### Required
 
 - `branch` (String) The branch this password belongs to.
-- `database` (String) The datanase this branch password belongs to.
+- `database` (String) The database this branch password belongs to.
 - `organization` (String) The organization this database branch password belongs to.
 
 ### Optional

--- a/go.sum
+++ b/go.sum
@@ -322,6 +322,8 @@ golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuX
 golang.org/x/term v0.2.0/go.mod h1:TVmDHMZPmdnySmBfhjOoOdhjzdE1h4u1VwSiw2l1Nuc=
 golang.org/x/term v0.5.0/go.mod h1:jMB1sMXY+tzblOD4FWmEbocvup2/aLOaQEp7JmGp78k=
 golang.org/x/term v0.6.0/go.mod h1:m6U89DPEgQRMq3DNkDClhWw02AUbt2daBVO4cn4Hv9U=
+golang.org/x/term v0.13.0 h1:bb+I9cTfFazGW51MZqBVmZy7+JEJMouUHTUSKVQLBek=
+golang.org/x/term v0.13.0/go.mod h1:LTmsnFJwVN6bCy1rVCoS+qHT1HhALEFxKncY3WNNh4U=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=

--- a/internal/provider/branch_resource_test.go
+++ b/internal/provider/branch_resource_test.go
@@ -1,0 +1,64 @@
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccBranchResource(t *testing.T) {
+	// TODO: This test currently fails because the provider returns immediately
+	//       after DB creation but the DB is still pending and so the branch creation
+	//       will fail. Unblock and finish this test once this issue is resolved.
+	t.Skip()
+
+	dbName := acctest.RandomWithPrefix("testacc-branch")
+	branchName := "two"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				Config: testAccBranchResourceConfig(dbName, branchName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("planetscale_branch.two", "name", branchName),
+					resource.TestCheckResourceAttr("planetscale_branch.two", "parent_branch", "main"),
+					resource.TestCheckResourceAttr("planetscale_branch.two", "sharded", "false"),
+				),
+			},
+			// ImportState testing
+			{
+				ResourceName:      "planetscale_branch.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// Update and Read testing
+			// TODO: Implement an update test.
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+
+// TODO: implement an out of bound deletion test like we have in the password and database tests.
+
+func testAccBranchResourceConfig(dbName, branchName string) string {
+	return fmt.Sprintf(`
+resource "planetscale_database" "test" {
+  organization   = "%s"
+  name           = "%s"
+  cluster_size   = "PS-10"
+  default_branch = "main"
+}
+
+resource "planetscale_branch" "two" {
+  organization  = "%s"
+  database      = planetscale_database.test.name
+  name          = "%s"
+  parent_branch = planetscale_database.test.default_branch
+}
+  `, testAccOrg, dbName, testAccOrg, branchName)
+}

--- a/internal/provider/database_resource_test.go
+++ b/internal/provider/database_resource_test.go
@@ -1,0 +1,98 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccDatabaseResource(t *testing.T) {
+	dbName := acctest.RandomWithPrefix("testacc-db")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				Config: testAccDatabaseResourceConfig(dbName, "PS-10"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// resource.TestCheckResourceAttr("planetscale_database.test", "id", "todo"),
+					resource.TestCheckResourceAttr("planetscale_database.test", "production_branches_count", "1"),
+					resource.TestCheckResourceAttr("planetscale_database.test", "default_branch", "main"),
+					resource.TestCheckResourceAttr("planetscale_database.test", "cluster_size", "PS-10"),
+				),
+			},
+			// ImportState testing
+			{
+				ResourceName:      "planetscale_database.test",
+				ImportStateId:     fmt.Sprintf("%s,%s", testAccOrg, dbName),
+				ImportState:       true,
+				ImportStateVerify: true,
+				// TODO: API does not return cluster_size which causes a diff on import. When fixed, remove this:
+				ImportStateVerifyIgnore: []string{"cluster_size"},
+			},
+			// Update and Read testing
+			{
+				Config: testAccDatabaseResourceConfig(dbName, "PS-20"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// resource.TestCheckResourceAttr("planetscale_database.test", "id", "todo"),
+					resource.TestCheckResourceAttr("planetscale_database.test", "production_branches_count", "1"),
+					resource.TestCheckResourceAttr("planetscale_database.test", "default_branch", "main"),
+					resource.TestCheckResourceAttr("planetscale_database.test", "cluster_size", "PS-20"),
+				),
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+
+// TestAccDatabaseResource_outOfBandDelete tests the out-of-band deletion of the database.
+// In this test we simulate the remote database has been deleted out of band, perhaps by
+// a user on the console or using pscale CLI.
+// https://github.com/planetscale/terraform-provider-planetscale/issues/53
+func TestAccDatabaseResource_OutOfBandDelete(t *testing.T) {
+	dbName := acctest.RandomWithPrefix("testacc-db-oob")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				Config: testAccDatabaseResourceConfig(dbName, "PS-10"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("planetscale_database.test", "production_branches_count", "1"),
+					resource.TestCheckResourceAttr("planetscale_database.test", "default_branch", "main"),
+					resource.TestCheckResourceAttr("planetscale_database.test", "cluster_size", "PS-10"),
+				),
+			},
+			// Test out-of-bands deletion of the database should produce a plan to recreate, not error.
+			{
+				ResourceName:       "planetscale_database.test",
+				RefreshState:       true,
+				ExpectNonEmptyPlan: true,
+				PreConfig: func() {
+					ctx := context.Background()
+					_, err := testAccAPIClient.DeleteDatabase(ctx, testAccOrg, dbName)
+					if err != nil {
+						t.Fatalf("PreConfig: failed to delete database: %s", err)
+					}
+				},
+			},
+		},
+	})
+}
+
+func testAccDatabaseResourceConfig(dbName string, clusterSize string) string {
+	return fmt.Sprintf(`
+resource "planetscale_database" "test" {
+  organization   = "%s"
+  name           = "%s"
+  cluster_size   = "%s"
+}
+`, testAccOrg, dbName, clusterSize)
+}

--- a/internal/provider/models_data_source.go
+++ b/internal/provider/models_data_source.go
@@ -1191,7 +1191,7 @@ func passwordDataSourceSchemaAttribute(computedName bool) map[string]schema.Attr
 			Required:    !computedName, Computed: computedName,
 		},
 		"database": schema.StringAttribute{
-			Description: "The datanase this branch password belongs to.",
+			Description: "The database this branch password belongs to.",
 			Required:    !computedName, Computed: computedName,
 		},
 		"branch": schema.StringAttribute{

--- a/internal/provider/organization_regions_data_source_test.go
+++ b/internal/provider/organization_regions_data_source_test.go
@@ -26,14 +26,13 @@ var regions = []string{
 }
 
 func TestAccOrganizationRegionsDataSource(t *testing.T) {
-	orgName := "planetscale-terraform-testing"
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			// Read testing
 			{
-				Config: testAccOrganizationRegionsDataSourceConfig(orgName),
+				Config: testAccOrganizationRegionsDataSourceConfig(testAccOrg),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrWith("data.planetscale_organization_regions.test", "regions.#", checkIntegerMin(1)),
 					resource.TestCheckResourceAttrWith("data.planetscale_organization_regions.test", "regions.0.slug", checkOneOf(regions...)),

--- a/internal/provider/organizations_data_source_test.go
+++ b/internal/provider/organizations_data_source_test.go
@@ -16,7 +16,7 @@ func TestAccOrganizationsDataSource(t *testing.T) {
 				Config: testAccOrganizationsDataSourceConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.planetscale_organizations.test", "organizations.#", "1"),
-					resource.TestCheckResourceAttr("data.planetscale_organizations.test", "organizations.0.name", "planetscale-terraform-testing"),
+					resource.TestCheckResourceAttr("data.planetscale_organizations.test", "organizations.0.name", testAccOrg),
 					resource.TestCheckResourceAttrSet("data.planetscale_organizations.test", "organizations.0.admin_only_production_access"),
 					resource.TestCheckResourceAttrSet("data.planetscale_organizations.test", "organizations.0.billing_email"),
 					resource.TestCheckResourceAttrSet("data.planetscale_organizations.test", "organizations.0.can_create_databases"),

--- a/internal/provider/password_resource_test.go
+++ b/internal/provider/password_resource_test.go
@@ -1,0 +1,155 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func TestAccPasswordResource(t *testing.T) {
+	dbName := acctest.RandomWithPrefix("testacc-passwd-db")
+	passwdName := acctest.RandomWithPrefix("testacc-passwd")
+	branchName := "main"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				Config: testAccPasswordResourceConfig(dbName, passwdName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("planetscale_password.test", "role", "admin"),
+					resource.TestCheckResourceAttr("planetscale_password.test", "branch", branchName),
+				),
+			},
+			// ImportState testing
+			{
+				ResourceName:      "planetscale_password.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				// Import requires: 'organization,database,branch,id' but 'id' of the password
+				// is only known after creation. Use a func to retrieve the ID from the state:
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					id, err := getPasswordIDFromState(s, "planetscale_password.test")
+					if err != nil {
+						return "", err
+					}
+					// Import requires: 'organization,database,branch,id'
+					return fmt.Sprintf("%s,%s,%s,%s", testAccOrg, dbName, branchName, id), nil
+				},
+				// The actual password is not returned by the API, so we can't verify it here:
+				ImportStateVerifyIgnore: []string{"plaintext"},
+			},
+			// Update and Read testing
+			// TODO: Implement a test for password Update. Best current idea is to update the
+			//       password's branch to a new branch, but that requires the ability to
+			//       create a database and branch in a single plan which is currently broken
+			//       due to the async nature of planetscale_database.
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+
+// TestAccPasswordResource_OutOfBandDelete tests the out-of-band deletion of a branch password.
+// In this test we simulate the password has been deleted out of band, perhaps by
+// a user on the console or using pscale CLI.
+// https://github.com/planetscale/terraform-provider-planetscale/issues/53
+func TestAccPasswordResource_OutOfBandDelete(t *testing.T) {
+	dbName := acctest.RandomWithPrefix("testacc-passwd-db")
+	passwdName := acctest.RandomWithPrefix("testacc-passwd")
+	branchName := "main"
+
+	passId := ""
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				Config: testAccPasswordResourceConfig(dbName, passwdName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("planetscale_password.test", "role", "admin"),
+					resource.TestCheckResourceAttr("planetscale_password.test", "branch", branchName),
+				),
+			},
+			// ImportState testing
+			{
+				ResourceName:      "planetscale_password.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					id, err := getPasswordIDFromState(s, "planetscale_password.test")
+					if err != nil {
+						return "", err
+					}
+					passId = id // save the ID for use in later steps' PreConfig func:
+					// Import requires: 'organization,database,branch,id'
+					return fmt.Sprintf("%s,%s,%s,%s", testAccOrg, dbName, branchName, id), nil
+				},
+				// The actual password is not returned by the API, so we can't verify it here:
+				ImportStateVerifyIgnore: []string{"plaintext"},
+			},
+			// Test out-of-bands deletion of the database should produce a plan to recreate, not error.
+			{
+				ResourceName:       "planetscale_password.test",
+				RefreshState:       true,
+				ExpectNonEmptyPlan: true,
+				PreConfig: func() {
+					ctx := context.Background()
+					if _, err := testAccAPIClient.DeletePassword(ctx, testAccOrg, dbName, branchName, passId); err != nil {
+						t.Fatalf("PreConfig: failed to delete password: %s", err)
+					}
+				},
+			},
+		},
+	})
+}
+
+func testAccPasswordResourceConfig(dbName, passwdName string) string {
+	return fmt.Sprintf(`
+resource "planetscale_database" "test" {
+  name           = "%s"
+  organization   = "%s"
+  cluster_size   = "PS-10"
+  default_branch = "main"
+}
+
+# TODO: Uncomment when the issue with branch creation after db creation is solved, then we can
+#       also expand the test coverage for password to include a change from one branch to another.
+# resource "planetscale_branch" "two" {
+#   name          = "TODO"
+#   organization  = "TODO"
+#   database      = planetscale_database.test.name
+#   parent_branch = planetscale_database.test.default_branch
+# }
+
+resource "planetscale_password" "test" {
+  name         = "%s"
+  organization = "%s"
+  database     = planetscale_database.test.name
+  branch       = planetscale_database.test.default_branch
+}
+  `, dbName, testAccOrg, passwdName, testAccOrg)
+}
+
+func getPasswordIDFromState(state *terraform.State, resourceName string) (string, error) {
+	// resourceName := "planetscale_password.test"
+	var rawState map[string]string
+	for _, m := range state.Modules {
+		if len(m.Resources) > 0 {
+			if v, ok := m.Resources[resourceName]; ok {
+				rawState = v.Primary.Attributes
+			}
+		}
+	}
+	if rawState == nil {
+		return "", fmt.Errorf("resource %s not found in state", resourceName)
+	}
+	return rawState["id"], nil
+}


### PR DESCRIPTION
addresses part of #53 

When a resource in the statefile has been deleted out of band, such as someone on the console or using pscale cli deleting it, terraform should remove it from state and plan to recreate it. However, we were treating 404s as fatal.

To solve this, the `Read()` method in each of the four resources now checks for 404 and removes the resource from state so that terraform will offer to recreate the resource

This PR also adds initial acceptance test coverage for `database`, `password`, and `branch` resources, including tests for the out-of-band deletion handling fixed by this PR. The `backup` resource is currently not working and so tests for it will be added in later PRs.