### PR TITLE
wait for db/branch readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,18 @@ Note that this provider builds on top of the OpenAPI part of the PlanetScale API
 
 Contributions should follow this workflow, or integrate with it.
 
+### Tests
+
+You will need to set either `PLANETSCALE_ACCESS_TOKEN` or `PLANETSCALE_SERVICE_TOKEN_NAME` and `PLANETSCALE_SERVICE_TOKEN` to run acceptance tests.
+
+The org to create resources under is currently hardcoded in the tests. You may need to change this to match your own org.  Acceptance tests create real resources in your PlanetScale org.
+
+Run all tests: `make testacc`
+
+Run specific test: `make testacc TESTARGS='-run ^TestAccBranchResource$'`
+
+Debug logs: `TF_PS_PROVIDER_DEBUG=1 TF_LOG=debug make testacc` (or `TF_LOG=trace`)
+
 ## License
 
 MPL v2.0

--- a/doc/dependency_decisions.yml
+++ b/doc/dependency_decisions.yml
@@ -1,79 +1,85 @@
 ---
 - - :permit
   - MIT
-  - :who:
-    :why:
+  - :who: 
+    :why: 
     :versions: []
     :when: 2023-09-25 21:54:03.091597000 Z
 - - :permit
   - New BSD
-  - :who:
-    :why:
+  - :who: 
+    :why: 
     :versions: []
     :when: 2023-09-25 21:54:05.834639000 Z
 - - :permit
   - Apache 2.0
-  - :who:
-    :why:
+  - :who: 
+    :why: 
     :versions: []
     :when: 2023-09-25 21:54:18.270178000 Z
 - - :permit
   - Simplified BSD
-  - :who:
-    :why:
+  - :who: 
+    :why: 
     :versions: []
     :when: 2023-09-25 21:54:35.110124000 Z
 - - :permit
   - Mozilla Public License 2.0
-  - :who:
-    :why:
+  - :who: 
+    :why: 
     :versions: []
     :when: 2023-09-25 21:54:43.394929000 Z
 - - :approve
   - github.com/hashicorp/go-plugin
-  - :who:
-    :why:
+  - :who: 
+    :why: 
     :versions: []
     :when: 2023-09-25 21:55:23.893162000 Z
 - - :approve
   - github.com/hashicorp/go-uuid
-  - :who:
-    :why:
+  - :who: 
+    :why: 
     :versions: []
     :when: 2023-09-25 21:55:32.748891000 Z
 - - :approve
   - github.com/hashicorp/terraform-plugin-framework
-  - :who:
-    :why:
+  - :who: 
+    :why: 
     :versions: []
     :when: 2023-09-25 21:55:56.398305000 Z
 - - :approve
   - github.com/hashicorp/terraform-plugin-go
-  - :who:
-    :why:
+  - :who: 
+    :why: 
     :versions: []
     :when: 2023-09-25 21:56:02.831960000 Z
 - - :approve
   - github.com/hashicorp/terraform-plugin-log
-  - :who:
-    :why:
+  - :who: 
+    :why: 
     :versions: []
     :when: 2023-09-25 21:56:11.501510000 Z
 - - :approve
   - github.com/hashicorp/terraform-registry-address
-  - :who:
-    :why:
+  - :who: 
+    :why: 
     :versions: []
     :when: 2023-09-25 21:56:21.325793000 Z
 - - :approve
   - github.com/hashicorp/terraform-svchost
-  - :who:
-    :why:
+  - :who: 
+    :why: 
     :versions: []
     :when: 2023-09-25 21:56:32.197702000 Z
 - - :approve
   - github.com/hashicorp/terraform-plugin-framework-validators
-  - :who:
-    :why:
+  - :who: 
+    :why: 
     :versions: []
     :when: 2023-10-11 21:59:00.000000000 Z
+- - :approve
+  - github.com/hashicorp/terraform-plugin-sdk/v2
+  - :who: 
+    :why: 
+    :versions: []
+    :when: 2024-09-08 00:50:30.334698638 Z

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework-validators v0.13.0
 	github.com/hashicorp/terraform-plugin-go v0.23.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
+	github.com/hashicorp/terraform-plugin-sdk/v2 v2.34.0
 	github.com/hashicorp/terraform-plugin-testing v1.5.1
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
 	github.com/pkg/errors v0.9.1
@@ -56,7 +57,6 @@ require (
 	github.com/hashicorp/logutils v1.0.0 // indirect
 	github.com/hashicorp/terraform-exec v0.21.0 // indirect
 	github.com/hashicorp/terraform-json v0.22.1 // indirect
-	github.com/hashicorp/terraform-plugin-sdk/v2 v2.34.0 // indirect
 	github.com/hashicorp/terraform-registry-address v0.2.3 // indirect
 	github.com/hashicorp/terraform-svchost v0.1.1 // indirect
 	github.com/hashicorp/yamux v0.1.1 // indirect

--- a/internal/provider/database_resource_test.go
+++ b/internal/provider/database_resource_test.go
@@ -12,7 +12,7 @@ import (
 func TestAccDatabaseResource(t *testing.T) {
 	dbName := acctest.RandomWithPrefix("testacc-db")
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
@@ -20,7 +20,6 @@ func TestAccDatabaseResource(t *testing.T) {
 			{
 				Config: testAccDatabaseResourceConfig(dbName, "PS-10"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					// resource.TestCheckResourceAttr("planetscale_database.test", "id", "todo"),
 					resource.TestCheckResourceAttr("planetscale_database.test", "production_branches_count", "1"),
 					resource.TestCheckResourceAttr("planetscale_database.test", "default_branch", "main"),
 					resource.TestCheckResourceAttr("planetscale_database.test", "cluster_size", "PS-10"),
@@ -39,7 +38,6 @@ func TestAccDatabaseResource(t *testing.T) {
 			{
 				Config: testAccDatabaseResourceConfig(dbName, "PS-20"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					// resource.TestCheckResourceAttr("planetscale_database.test", "id", "todo"),
 					resource.TestCheckResourceAttr("planetscale_database.test", "production_branches_count", "1"),
 					resource.TestCheckResourceAttr("planetscale_database.test", "default_branch", "main"),
 					resource.TestCheckResourceAttr("planetscale_database.test", "cluster_size", "PS-20"),
@@ -57,7 +55,7 @@ func TestAccDatabaseResource(t *testing.T) {
 func TestAccDatabaseResource_OutOfBandDelete(t *testing.T) {
 	dbName := acctest.RandomWithPrefix("testacc-db-oob")
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{

--- a/internal/provider/organization_data_source_test.go
+++ b/internal/provider/organization_data_source_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestAccOrganizationDataSource(t *testing.T) {
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{

--- a/internal/provider/organization_regions_data_source_test.go
+++ b/internal/provider/organization_regions_data_source_test.go
@@ -26,7 +26,7 @@ var regions = []string{
 }
 
 func TestAccOrganizationRegionsDataSource(t *testing.T) {
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{

--- a/internal/provider/organizations_data_source_test.go
+++ b/internal/provider/organizations_data_source_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestAccOrganizationsDataSource(t *testing.T) {
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -17,8 +17,10 @@ import (
 
 const testAccOrg = "planetscale-terraform-testing"
 
+var debugProvider = os.Getenv("TF_PS_PROVIDER_DEBUG") != ""
+
 var testAccProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServer, error){
-	"planetscale": providerserver.NewProtocol6WithError(New("test", false)()),
+	"planetscale": providerserver.NewProtocol6WithError(New("test", debugProvider)()),
 }
 
 var testAccAPIClient *planetscale.Client


### PR DESCRIPTION
- Added readiness polling for database and branch resources to ensure they are fully ready before proceeding with operations.

- Applied the 404 handling fix on branch resource:
  - Now removes resource from state if branch is deleted out-of-band, similar to the fix applied to database resource, instead of fatally erroring

- Parallelized tests