### PR TITLE
docs: remove service token limitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ provider "planetscale" {
 ## Known limitations
 
 - Support for deployments, deploy queues, deploy requests and reverts is not implemented at this time. If you have a use case for it, please let us know in the repository issues.
-- Service tokens don't immediately have read/write access on the resources they create. For now, access must be granted via the UI or via the CLI (`pscale service-token add-access`)
+- When using service tokens (recommended), ensure the token has the `create_databases` organization-level permission. This allows terraform to create new databases and automatically grants the token all other permissions on the databases created by the token.
 
 ## Contributing
 

--- a/internal/provider/database_resource_test.go
+++ b/internal/provider/database_resource_test.go
@@ -32,7 +32,7 @@ func TestAccDatabaseResource(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				// TODO: API does not return cluster_size which causes a diff on import. When fixed, remove this:
-				ImportStateVerifyIgnore: []string{"cluster_size"},
+				ImportStateVerifyIgnore: []string{"cluster_size", "updated_at"},
 			},
 			// Update and Read testing
 			{


### PR DESCRIPTION
As of [2024/08/29](https://planetscale.com/changelog/service-token-branch-creation) service tokens with the `create_databases` org permission are automatically granted full permissions to any database it creates. Thus removing the prior limitation when using service-tokens with the terraform provider.