### PR TITLE
ci: add opentofu test coverage

### DIFF
--- a/.github/workflows/test-extensive.yml
+++ b/.github/workflows/test-extensive.yml
@@ -36,25 +36,19 @@ jobs:
         with:
           version: latest
 
-  test:
-    name: integration
+  test-terraform:
+    name: integration-terraform
     needs: build
     runs-on: ubuntu-latest
+    if: '!github.event.pull_request.head.repo.fork'
     timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
         terraform:
-          # TODO: only test one for now since we are creating and destroying actual
-          # resources. Decide which versions to support when we are closer to a supported
-          # release.
-          # - '1.0.*'
-          # - '1.1.*'
-          # - '1.2.*'
-          # - '1.3.*'
-          # - '1.4.*'
-          # - '1.5.*'
           - '1.6.*'
+          - '1.9.*'
+          - latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -66,6 +60,37 @@ jobs:
         with:
           terraform_version: ${{ matrix.terraform }}
           terraform_wrapper: false
+      - run: make testacc
+        env:
+          PLANETSCALE_SERVICE_TOKEN_NAME: ${{ secrets.PLANETSCALE_SERVICE_TOKEN_NAME }}
+          PLANETSCALE_SERVICE_TOKEN: ${{ secrets.PLANETSCALE_SERVICE_TOKEN }}
+        timeout-minutes: 10
+
+  test-tofu:
+    name: integration-tofu
+    needs: build
+    runs-on: ubuntu-latest
+    if: '!github.event.pull_request.head.repo.fork'
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        tofu:
+          - '1.6.*'
+          - '1.7.*'
+          - '1.8.*'
+          - latest
+    steps:
+      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+        with:
+          go-version-file: 'go.mod'
+      - uses: opentofu/setup-opentofu@v1
+        with:
+          tofu_version: ${{ matrix.tofu }}
+          tofu_wrapper: false
       - run: make testacc
         env:
           PLANETSCALE_SERVICE_TOKEN_NAME: ${{ secrets.PLANETSCALE_SERVICE_TOKEN_NAME }}

--- a/.github/workflows/test-extensive.yml
+++ b/.github/workflows/test-extensive.yml
@@ -18,6 +18,11 @@ on:
 permissions:
   contents: read
 
+# Ensures only 1 action runs per PR and previous is canceled on new trigger
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: build
@@ -44,6 +49,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       fail-fast: false
+      max-parallel: 2
       matrix:
         terraform:
           - '1.6.*'
@@ -73,6 +79,7 @@ jobs:
     if: '!github.event.pull_request.head.repo.fork'
     timeout-minutes: 15
     strategy:
+      max-parallel: 2
       fail-fast: false
       matrix:
         tofu:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,4 +64,3 @@ jobs:
         with:
           go-version-file: 'go.mod'
       - run: go test -cover ./...
-        timeout-minutes: 10

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
           go-version-file: 'go.mod'
       - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
         with:
-          terraform_version: 1.6.1
+          terraform_version: 1.9.*
           terraform_wrapper: false
       - run: go generate -x ./...
       - name: git diff
@@ -49,8 +49,8 @@ jobs:
           git diff --compact-summary --exit-code || \
             (echo; echo "Unexpected difference in directories after code generation. Run 'go generate ./...' command and commit."; exit 1)
 
-  test:
-    name: unit
+  test-terraform:
+    name: unit-terraform
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -58,16 +58,9 @@ jobs:
       fail-fast: false
       matrix:
         terraform:
-          # TODO: only test one for now since we are creating and destroying actual
-          # resources. Decide which versions to support when we are closer to a supported
-          # release.
-          # - '1.0.*'
-          # - '1.1.*'
-          # - '1.2.*'
-          # - '1.3.*'
-          # - '1.4.*'
-          # - '1.5.*'
           - '1.6.*'
+          - '1.9.*'
+          - latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -79,5 +72,32 @@ jobs:
         with:
           terraform_version: ${{ matrix.terraform }}
           terraform_wrapper: false
+      - run: go test -cover ./...
+        timeout-minutes: 10
+
+  test-opentofu:
+    name: unit-opentofu
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        tofu:
+          - '1.6.*'
+          - '1.7.*'
+          - '1.8.*'
+          - latest
+    steps:
+      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+        with:
+          go-version-file: 'go.mod'
+      - uses: opentofu/setup-opentofu@v1
+        with:
+          tofu_version: ${{ matrix.tofu }}
+          tofu_wrapper: false
       - run: go test -cover ./...
         timeout-minutes: 10

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,8 @@ on:
     paths-ignore:
       - 'README.md'
   push:
+    branches:
+      - main
     paths-ignore:
       - 'README.md'
 
@@ -49,18 +51,11 @@ jobs:
           git diff --compact-summary --exit-code || \
             (echo; echo "Unexpected difference in directories after code generation. Run 'go generate ./...' command and commit."; exit 1)
 
-  test-terraform:
-    name: unit-terraform
+  unit-tests:
+    name: unit-tests
     needs: build
     runs-on: ubuntu-latest
-    timeout-minutes: 15
-    strategy:
-      fail-fast: false
-      matrix:
-        terraform:
-          - '1.6.*'
-          - '1.9.*'
-          - latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -68,36 +63,5 @@ jobs:
       - uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
         with:
           go-version-file: 'go.mod'
-      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
-        with:
-          terraform_version: ${{ matrix.terraform }}
-          terraform_wrapper: false
-      - run: go test -cover ./...
-        timeout-minutes: 10
-
-  test-opentofu:
-    name: unit-opentofu
-    needs: build
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    strategy:
-      fail-fast: false
-      matrix:
-        tofu:
-          - '1.6.*'
-          - '1.7.*'
-          - '1.8.*'
-          - latest
-    steps:
-      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
-        with:
-          persist-credentials: false
-      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
-        with:
-          go-version-file: 'go.mod'
-      - uses: opentofu/setup-opentofu@v1
-        with:
-          tofu_version: ${{ matrix.tofu }}
-          tofu_wrapper: false
       - run: go test -cover ./...
         timeout-minutes: 10

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,5 +1,9 @@
 default: testacc
 
+.PHONY: build
+build:
+	CGO_ENABLED=0 go build -v -trimpath .
+
 .PHONY: lint
 lint:
 	golangci-lint run -v ./...
@@ -14,3 +18,7 @@ generate:
 	bash ./script/update_openapi_spec
 	bash ./script/generate
 	go generate ./...
+
+.PHONY: sweep
+sweep:
+	bash ./script/sweep

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ Run specific test: `make testacc TESTARGS='-run ^TestAccBranchResource$'`
 
 Debug logs: `TF_PS_PROVIDER_DEBUG=1 TF_LOG=debug make testacc` (or `TF_LOG=trace`)
 
+From time to time it may be necessary to manually cleanup databases created by the acceptance tests. Running `make sweep` will delete all db's created by the acceptance tests older than 24 hours. Alternatively you may run `AGE_SECS=900 make sweep` to supply a shorter age threshold.
+
 ## License
 
 MPL v2.0

--- a/internal/provider/branch_resource_test.go
+++ b/internal/provider/branch_resource_test.go
@@ -28,10 +28,11 @@ func TestAccBranchResource(t *testing.T) {
 			},
 			// ImportState testing
 			{
-				ResourceName:      "planetscale_branch.test",
-				ImportStateId:     fmt.Sprintf("%s,%s,%s", testAccOrg, dbName, branchName),
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "planetscale_branch.test",
+				ImportStateId:           fmt.Sprintf("%s,%s,%s", testAccOrg, dbName, branchName),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"updated_at", "schema_last_updated_at"},
 			},
 			// Update and Read testing
 			// TODO: Implement an update test.

--- a/internal/provider/database_resource_test.go
+++ b/internal/provider/database_resource_test.go
@@ -31,8 +31,8 @@ func TestAccDatabaseResource(t *testing.T) {
 				ImportStateId:     fmt.Sprintf("%s,%s", testAccOrg, dbName),
 				ImportState:       true,
 				ImportStateVerify: true,
-				// TODO: API does not return cluster_size which causes a diff on import. When fixed, remove this:
-				ImportStateVerifyIgnore: []string{"cluster_size"},
+				// TODO: API does not return cluster_size which causes a diff on import. When fixed, remove it.
+				ImportStateVerifyIgnore: []string{"cluster_size", "updated_at"},
 			},
 			// Update and Read testing
 			{

--- a/script/sweep
+++ b/script/sweep
@@ -7,9 +7,11 @@ ORG="${ORG:-planetscale-terraform-testing}"
 AGE_SECS="${AGE_SECS:-86400}"
 
 pscale database list --org "$ORG" --format json |
-  jq --arg age "$AGE_SECS" -r '.[] | select(
+	jq --arg age "$AGE_SECS" \
+		-r '.[] | select(
     (.name | startswith("testacc")) and
-    (.created_at | sub("\\.\\d+"; "") | fromdateiso8601 < (now - ($age | tonumber)))).name' |
-  while read -r dbname; do
-    pscale database delete "$dbname" --org "$ORG" --force
-  done
+    (.created_at | sub("\\.\\d+"; "") | fromdateiso8601 < (now - ($age | tonumber))))
+    .name' |
+	while read -r dbname; do
+		pscale database delete "$dbname" --org "$ORG" --force
+	done

--- a/script/sweep
+++ b/script/sweep
@@ -4,11 +4,12 @@
 set -eou pipefail
 
 ORG="${ORG:-planetscale-terraform-testing}"
+AGE_SECS="${AGE_SECS:-86400}"
 
 pscale database list --org "$ORG" --format json |
-  jq -r '.[] | select(
+  jq --arg age "$AGE_SECS" -r '.[] | select(
     (.name | startswith("testacc")) and
-    (.created_at | sub("\\.\\d+"; "") | fromdateiso8601 < (now - 86400))).name' |
+    (.created_at | sub("\\.\\d+"; "") | fromdateiso8601 < (now - ($age | tonumber)))).name' |
   while read -r dbname; do
     pscale database delete "$dbname" --org "$ORG" --force
   done

--- a/script/sweep
+++ b/script/sweep
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# delete db's older than 24 hours in the test org whose name starts with "testacc"
+
+set -eou pipefail
+
+ORG="${ORG:-planetscale-terraform-testing}"
+
+pscale database list --org "$ORG" --format json |
+  jq -r '.[] | select(
+    (.name | startswith("testacc")) and
+    (.created_at | sub("\\.\\d+"; "") | fromdateiso8601 < (now - 86400))).name' |
+  while read -r dbname; do
+    pscale database delete "$dbname" --org "$ORG" --force
+  done


### PR DESCRIPTION
1. added opentofu to the acceptance tests in GHA
2. updated versions of terraform we test against to include more recent versions
3. limited concurrency on acceptance tests in GHA
4. simplified the `basic tests` (unit tests) workflow by removing unnecessary terraform installs
5. added a `make sweep` task and script to cleanup `testacc-*` databases in the test org that can be left over by failed or canceled acceptance test runs