### PR TITLE
fix: `planetscale_branch` data source crash

### DIFF
--- a/.github/workflows/test-extensive.yml
+++ b/.github/workflows/test-extensive.yml
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
         with:
           go-version-file: 'go.mod'
-      - run: go build -v .
+      - run: make build
       - name: Run linters
         uses: golangci/golangci-lint-action@971e284b6050e8a5849b72094c50ab08da042db8 # v6
         with:
@@ -54,10 +54,10 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     if: '!github.event.pull_request.head.repo.fork'
-    timeout-minutes: 15
+    timeout-minutes: 30
     strategy:
       fail-fast: false
-      max-parallel: 2
+      max-parallel: 1
       matrix:
         terraform:
           - '1.6.*'
@@ -85,9 +85,9 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     if: '!github.event.pull_request.head.repo.fork'
-    timeout-minutes: 15
+    timeout-minutes: 30
     strategy:
-      max-parallel: 2
+      max-parallel: 1
       fail-fast: false
       matrix:
         tofu:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -11,7 +11,7 @@ lint:
 # Run acceptance tests
 .PHONY: testacc
 testacc:
-	TF_ACC=1 go test ./... -v $(TESTARGS) -timeout 120m
+	TF_ACC=1 go test -parallel=2 ./... -v $(TESTARGS) -timeout 120m
 
 .PHONY: generate
 generate:

--- a/internal/provider/branch_data_source_test.go
+++ b/internal/provider/branch_data_source_test.go
@@ -1,0 +1,60 @@
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccBranchDataSource(t *testing.T) {
+	dbName := acctest.RandomWithPrefix("testacc-branch-ds")
+	branchName := acctest.RandomWithPrefix("branch")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBranchDataSourceConfig(dbName, branchName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.planetscale_branch.test", "name", branchName),
+					resource.TestCheckResourceAttr("data.planetscale_branch.test", "database", dbName),
+					resource.TestCheckResourceAttr("data.planetscale_branch.test", "organization", testAccOrg),
+					resource.TestCheckResourceAttr("data.planetscale_branch.test", "parent_branch", "main"),
+					resource.TestCheckResourceAttr("data.planetscale_branch.test", "production", "false"),
+					resource.TestCheckResourceAttr("data.planetscale_branch.test", "sharded", "false"),
+					resource.TestCheckResourceAttrSet("data.planetscale_branch.test", "id"),
+					resource.TestCheckResourceAttrSet("data.planetscale_branch.test", "created_at"),
+					resource.TestCheckResourceAttrSet("data.planetscale_branch.test", "updated_at"),
+					resource.TestCheckResourceAttrSet("data.planetscale_branch.test", "mysql_edge_address"),
+				),
+			},
+		},
+	})
+}
+
+func testAccBranchDataSourceConfig(dbName, branchName string) string {
+	return fmt.Sprintf(`
+resource "planetscale_database" "test" {
+	organization   = "%s"
+	name           = "%s"
+	cluster_size   = "PS-10"
+	default_branch = "main"
+}
+
+resource "planetscale_branch" "test" {
+	organization  = planetscale_database.test.organization
+	database      = planetscale_database.test.name
+	name          = "%s"
+	parent_branch = planetscale_database.test.default_branch
+}
+
+data "planetscale_branch" "test" {
+	organization = planetscale_branch.test.organization
+	database     = planetscale_branch.test.database
+	name         = planetscale_branch.test.name
+}
+`, testAccOrg, dbName, branchName)
+}

--- a/internal/provider/models_data_source.go
+++ b/internal/provider/models_data_source.go
@@ -567,6 +567,7 @@ type branchDataSourceModel struct {
 	CreatedAt                   types.String                       `tfsdk:"created_at"`
 	HtmlUrl                     types.String                       `tfsdk:"html_url"`
 	Id                          types.String                       `tfsdk:"id"`
+	InitialRestoreId            types.String                       `tfsdk:"initial_restore_id"`
 	MysqlAddress                types.String                       `tfsdk:"mysql_address"`
 	MysqlEdgeAddress            types.String                       `tfsdk:"mysql_edge_address"`
 	ParentBranch                types.String                       `tfsdk:"parent_branch"`


### PR DESCRIPTION
Given a `main.tf` such as:

```hcl
provider "planetscale" {}

resource "planetscale_database" "mydb" {
  name         = "mydb"
  organization = "planetscale-terraform-testing"

  allow_data_branching          = false
  cluster_size                  = "PS_10"
  default_branch                = "main"
  production_branch_web_console = false
  region                        = "us-east"
}

resource "planetscale_branch" "staging" {
  name          = "staging"
  database      = planetscale_database.mydb.name
  organization  = planetscale_database.mydb.organization
  parent_branch = planetscale_database.mydb.default_branch
  production    = false
}

data "planetscale_branch" "staging" {
  database     = planetscale_database.mydb.name
  organization = planetscale_database.mydb.organization
  name         = planetscale_branch.staging.name
}

output "branch" {
  value = data.planetscale_branch.staging
}
```

A `terraform plan` will crash with:

> Planning failed. Terraform encountered an error while generating this plan.
>
> ╷
> │ Error: Value Conversion Error
> │
> │   with data.planetscale_branch.staging,
> │ An unexpected error was encountered trying to convert tftypes.Value into provider.branchDataSourceModel. This is always an error in the provider. Please report the following to the provider developer:
> │
> │ mismatch between struct and object: Object defines fields not found in struct: initial_restore_id.

Fix by adding the missing `initial_restore_id` field to the `branchDataSourceModel` struct and include a acceptance test to cover the `planetscale_branch` data source.