### PR TITLE
chore: fix remaining service token environment variable docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ page_title: "planetscale Provider"
 subcategory: ""
 description: |-
   The PlanetScale provider allows using the OpenAPI surface of our public API. To use this provider, one of the following are required:
-  access token credentials, configured or stored in the environment variable PLANETSCALE_ACCESS_TOKENservice token credentials, configured or stored in the environment variables PLANETSCALE_SERVICE_TOKEN_NAME and PLANETSCALE_SERVICE_TOKEN
+  access token credentials, configured or stored in the environment variable PLANETSCALE_ACCESS_TOKENservice token credentials, configured or stored in the environment variables PLANETSCALE_SERVICE_TOKEN_ID and PLANETSCALE_SERVICE_TOKEN
   Note that the provider is not production ready and only for early testing at this time.
   Known limitations:
   Support for deployments, deploy queues, deploy requests and reverts is not implemented at this time. If you have a use case for it, please let us know in the repository issues.When using service tokens (recommended), ensure the token has the create_databases organization-level permission. This allows terraform to create new databases and automatically grants the token all other permissions on the databases created by the token.
@@ -15,7 +15,7 @@ description: |-
 The PlanetScale provider allows using the OpenAPI surface of our public API. To use this provider, one of the following are required:
 
 - access token credentials, configured or stored in the environment variable `PLANETSCALE_ACCESS_TOKEN`
-- service token credentials, configured or stored in the environment variables `PLANETSCALE_SERVICE_TOKEN_NAME` and `PLANETSCALE_SERVICE_TOKEN`
+- service token credentials, configured or stored in the environment variables `PLANETSCALE_SERVICE_TOKEN_ID` and `PLANETSCALE_SERVICE_TOKEN`
 
 Note that the provider is not production ready and only for early testing at this time.
 
@@ -44,7 +44,7 @@ provider "planetscale" {
 
 ### Optional
 
-- `access_token` (String, Sensitive) Name of the service token to use. Alternatively, use `PLANETSCALE_SERVICE_TOKEN_NAME`. Mutually exclusive with `service_token_name` and `service_token`.
+- `access_token` (String, Sensitive) Name of the service token to use. Alternatively, use `PLANETSCALE_SERVICE_TOKEN_ID`. Mutually exclusive with `service_token_id` and `service_token`.
 - `endpoint` (String) If set, points the API client to a different endpoint than `https:://api.planetscale.com/v1`.
 - `service_token` (String, Sensitive) Value of the service token to use. Alternatively, use `PLANETSCALE_SERVICE_TOKEN`. Mutually exclusive with `access_token`.
 - `service_token_id` (String) ID of the service token to use. Alternatively, use `PLANETSCALE_SERVICE_TOKEN_ID`. Mutually exclusive with `access_token`.

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -48,7 +48,8 @@ func (p *PlanetScaleProvider) Metadata(ctx context.Context, req provider.Metadat
 func (p *PlanetScaleProvider) ConfigValidators(context.Context) []provider.ConfigValidator {
 	return []provider.ConfigValidator{
 		providervalidator.Conflicting(path.MatchRoot("access_token"), path.MatchRoot("service_token")),
-		providervalidator.Conflicting(path.MatchRoot("access_token"), path.MatchRoot("service_token_name")),
+		providervalidator.Conflicting(path.MatchRoot("access_token"), path.MatchRoot("service_token_id")),
+		providervalidator.Conflicting(path.MatchRoot("access_token"), path.MatchRoot("service_token_name")), // service_token_name is deprecated
 	}
 }
 
@@ -57,7 +58,7 @@ func (p *PlanetScaleProvider) Schema(ctx context.Context, req provider.SchemaReq
 		MarkdownDescription: `The PlanetScale provider allows using the OpenAPI surface of our public API. To use this provider, one of the following are required:
 
 - access token credentials, configured or stored in the environment variable ` + "`PLANETSCALE_ACCESS_TOKEN`" + `
-- service token credentials, configured or stored in the environment variables ` + "`PLANETSCALE_SERVICE_TOKEN_NAME`" + ` and ` + "`PLANETSCALE_SERVICE_TOKEN`" + `
+- service token credentials, configured or stored in the environment variables ` + "`PLANETSCALE_SERVICE_TOKEN_ID`" + ` and ` + "`PLANETSCALE_SERVICE_TOKEN`" + `
 
 Note that the provider is not production ready and only for early testing at this time.
 
@@ -70,7 +71,7 @@ Known limitations:
 				Optional:            true,
 			},
 			"access_token": schema.StringAttribute{
-				MarkdownDescription: "Name of the service token to use. Alternatively, use `PLANETSCALE_SERVICE_TOKEN_NAME`. Mutually exclusive with `service_token_name` and `service_token`.",
+				MarkdownDescription: "Name of the service token to use. Alternatively, use `PLANETSCALE_SERVICE_TOKEN_ID`. Mutually exclusive with `service_token_id` and `service_token`.",
 				Optional:            true,
 				Sensitive:           true,
 				Validators: []validator.String{
@@ -149,7 +150,7 @@ func (p *PlanetScaleProvider) Configure(ctx context.Context, req provider.Config
 	// Adding this to `resp.Diagnostics` ensures it will be printed during typical
 	// terraform operations, whereas logging with `tflog.Warn()` will only show if the
 	// users specifies the `TF_LOG` env var.
-	if serviceTokenName != "" && serviceTokenID == "" {
+	if serviceTokenName != "" {
 		resp.Diagnostics.AddWarning(
 			"Deprecated Configuration",
 			"PLANETSCALE_SERVICE_TOKEN_NAME is deprecated. Please use PLANETSCALE_SERVICE_TOKEN_ID instead.",


### PR DESCRIPTION
Release v0.2.1 missed a few spots in the documentation that were still referencing the deprecated `PLANETSCALE_SERVICE_TOKEN_NAME` environment variable.

Added test coverage for the provider's Configure() function since its logic now handles both old and new variable names.