### PR TITLE
fix multiple `planetscale_database` param handling bugs

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,7 +9,8 @@ linters:
   enable:
     - durationcheck
     - errcheck
-    - exportloopref
+    # TODO: enable copyloopvar
+    #- copyloopvar
     - forcetypeassert
     - godot
     - gofmt
@@ -20,7 +21,7 @@ linters:
     - nilerr
     - predeclared
     - staticcheck
-    - tenv
+    - usetesting
     - unconvert
     - unparam
     - unused

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -32,7 +32,7 @@ builds:
         goarch: "386"
     binary: "{{ .ProjectName }}_v{{ .Version }}"
 archives:
-  - format: zip
+  - formats: ["zip"]
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 checksum:
   extra_files:

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,7 +45,7 @@ provider "planetscale" {
 ### Optional
 
 - `access_token` (String, Sensitive) Name of the service token to use. Alternatively, use `PLANETSCALE_SERVICE_TOKEN_ID`. Mutually exclusive with `service_token_id` and `service_token`.
-- `endpoint` (String) If set, points the API client to a different endpoint than `https:://api.planetscale.com/v1`.
+- `endpoint` (String) If set, points the API client to a different endpoint than `https://api.planetscale.com/v1`.
 - `service_token` (String, Sensitive) Value of the service token to use. Alternatively, use `PLANETSCALE_SERVICE_TOKEN`. Mutually exclusive with `access_token`.
 - `service_token_id` (String) ID of the service token to use. Alternatively, use `PLANETSCALE_SERVICE_TOKEN_ID`. Mutually exclusive with `access_token`.
 - `service_token_name` (String, Deprecated) Name of the service token to use. Alternatively, use `PLANETSCALE_SERVICE_TOKEN_NAME`. Mutually exclusive with `access_token`. (Deprecated, use `service_token_id` instead)

--- a/docs/resources/database.md
+++ b/docs/resources/database.md
@@ -21,6 +21,7 @@ Known limitations:
 resource "planetscale_database" "example" {
   organization = "example"
   name         = "anotherdb"
+  cluster_size = "PS_10"
 }
 ```
 
@@ -29,6 +30,7 @@ resource "planetscale_database" "example" {
 
 ### Required
 
+- `cluster_size` (String) The default plan size of the database's branches.
 - `name` (String) The name of this database.
 - `organization` (String) The organization this database belongs to.
 
@@ -36,14 +38,10 @@ resource "planetscale_database" "example" {
 
 - `allow_data_branching` (Boolean) Whether seeding branches with data is enabled for all branches.
 - `automatic_migrations` (Boolean) Whether to automatically manage Rails migrations during deploy requests.
-- `cluster_size` (String) The size of the database cluster plan.
 - `default_branch` (String) The default branch for the database.
 - `insights_raw_queries` (Boolean) The URL to see this database's branches in the web UI.
-- `issues_count` (Number) The total number of ongoing issues within a database.
 - `migration_framework` (String) Framework used for applying migrations.
 - `migration_table_name` (String) Table name to use for copying schema migration data.
-- `multiple_admins_required_for_deletion` (Boolean) If the database requires multiple admins for deletion.
-- `plan` (String) The database plan.
 - `production_branch_web_console` (Boolean) Whether web console is enabled for production branches.
 - `region` (String) The region the database lives in.
 - `require_approval_for_deploy` (Boolean) Whether an approval is required to deploy schema changes to this database.
@@ -63,6 +61,9 @@ resource "planetscale_database" "example" {
 - `development_branches_count` (Number) The total number of database development branches.
 - `html_url` (String) The total number of database development branches.
 - `id` (String) The ID of the database.
+- `issues_count` (Number) The total number of ongoing issues within a database.
+- `multiple_admins_required_for_deletion` (Boolean) If the database requires multiple admins for deletion.
+- `plan` (String) The database plan.
 - `production_branches_count` (Number) The total number of database production branches.
 - `ready` (Boolean) If the database is ready to be used.
 - `schema_last_updated_at` (String) When the default branch schema was last changed.

--- a/docs/resources/database.md
+++ b/docs/resources/database.md
@@ -37,7 +37,7 @@ resource "planetscale_database" "example" {
 ### Optional
 
 - `allow_data_branching` (Boolean) Whether seeding branches with data is enabled for all branches.
-- `automatic_migrations` (Boolean) Whether to automatically manage Rails migrations during deploy requests.
+- `automatic_migrations` (Boolean) Whether to automatically manage migrations during deploy requests. If true, `migration_table_name` and `migration_framework` must be set.
 - `default_branch` (String) The default branch for the database.
 - `insights_raw_queries` (Boolean) The URL to see this database's branches in the web UI.
 - `migration_framework` (String) Framework used for applying migrations.

--- a/examples/resources/planetscale_database/resource.tf
+++ b/examples/resources/planetscale_database/resource.tf
@@ -1,4 +1,5 @@
 resource "planetscale_database" "example" {
   organization = "example"
   name         = "anotherdb"
+  cluster_size = "PS_10"
 }

--- a/internal/provider/database_resource.go
+++ b/internal/provider/database_resource.go
@@ -146,6 +146,14 @@ Known limitations:
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
+			"cluster_size": schema.StringAttribute{
+				Description: "The default plan size of the database's branches.",
+				Required:    true, PlanModifiers: []planmodifier.String{
+					// TODO(joem): Web console supports changing cluster_size without recreation, but the API does not
+					// currently expose this. Once the API supports this, change this to be updatable without recreation.
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
 
 			"id": schema.StringAttribute{
 				Description: "The ID of the database.",
@@ -252,7 +260,7 @@ Known limitations:
 			},
 			"issues_count": schema.Float64Attribute{
 				Description: "The total number of ongoing issues within a database.",
-				Computed:    true, Optional: true,
+				Computed:    true,
 			},
 			"migration_framework": schema.StringAttribute{
 				Description: "Framework used for applying migrations.",
@@ -264,15 +272,11 @@ Known limitations:
 			},
 			"multiple_admins_required_for_deletion": schema.BoolAttribute{
 				Description: "If the database requires multiple admins for deletion.",
-				Computed:    true, Optional: true,
+				Computed:    true,
 			},
 			"plan": schema.StringAttribute{
 				Description: "The database plan.",
-				Computed:    true, Optional: true,
-			},
-			"cluster_size": schema.StringAttribute{
-				Description: "The size of the database cluster plan.",
-				Computed:    true, Optional: true,
+				Computed:    true,
 			},
 			"production_branch_web_console": schema.BoolAttribute{
 				Description: "Whether web console is enabled for production branches.",

--- a/internal/provider/database_resource_test.go
+++ b/internal/provider/database_resource_test.go
@@ -1,9 +1,11 @@
 package provider
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"testing"
+	"text/template"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -16,15 +18,20 @@ func TestAccDatabaseResource(t *testing.T) {
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
-			// Create and Read testing
+			// Initial creation with required fields
 			{
-				Config: testAccDatabaseResourceConfig(dbName, "PS-10"),
+				Config: testAccDatabaseResourceConfigTemplate(map[string]string{
+					"organization": testAccOrg,
+					"name":         dbName,
+					"cluster_size": "PS-10",
+				}),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("planetscale_database.test", "production_branches_count", "1"),
-					resource.TestCheckResourceAttr("planetscale_database.test", "default_branch", "main"),
 					resource.TestCheckResourceAttr("planetscale_database.test", "cluster_size", "PS-10"),
+					// Check defaults are set correctly
+					resource.TestCheckResourceAttr("planetscale_database.test", "allow_data_branching", "false"),
 				),
 			},
+
 			// ImportState testing
 			{
 				ResourceName:      "planetscale_database.test",
@@ -34,16 +41,128 @@ func TestAccDatabaseResource(t *testing.T) {
 				// TODO: API does not return cluster_size which causes a diff on import. When fixed, remove it.
 				ImportStateVerifyIgnore: []string{"cluster_size", "updated_at"},
 			},
-			// Update and Read testing
+
+			// Test updateable settings
+			//
+			// Enable data branching
 			{
-				Config: testAccDatabaseResourceConfig(dbName, "PS-20"),
+				Config: testAccDatabaseResourceConfigTemplate(map[string]string{
+					"organization":         testAccOrg,
+					"name":                 dbName,
+					"cluster_size":         "PS-10",
+					"allow_data_branching": "true",
+				}),
+				ConfigPlanChecks: checkExpectUpdate("planetscale_database.test"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("planetscale_database.test", "production_branches_count", "1"),
-					resource.TestCheckResourceAttr("planetscale_database.test", "default_branch", "main"),
-					resource.TestCheckResourceAttr("planetscale_database.test", "cluster_size", "PS-20"),
+					resource.TestCheckResourceAttr("planetscale_database.test", "allow_data_branching", "true"),
 				),
 			},
-			// Delete testing automatically occurs in TestCase
+
+			// Enable automatic migrations
+			{
+				Config: testAccDatabaseResourceConfigTemplate(map[string]string{
+					"organization":         testAccOrg,
+					"name":                 dbName,
+					"cluster_size":         "PS-10",
+					"allow_data_branching": "true",
+					"automatic_migrations": "true",
+				}),
+				ConfigPlanChecks: checkExpectUpdate("planetscale_database.test"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("planetscale_database.test", "automatic_migrations", "true"),
+				),
+			},
+			// Enable insights raw queries
+			{
+				Config: testAccDatabaseResourceConfigTemplate(map[string]string{
+					"organization":         testAccOrg,
+					"name":                 dbName,
+					"cluster_size":         "PS-10",
+					"allow_data_branching": "true",
+					"automatic_migrations": "true",
+					"insights_raw_queries": "true",
+				}),
+				ConfigPlanChecks: checkExpectUpdate("planetscale_database.test"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("planetscale_database.test", "insights_raw_queries", "true"),
+				),
+			},
+			// Set migration framework
+			{
+				Config: testAccDatabaseResourceConfigTemplate(map[string]string{
+					"organization":         testAccOrg,
+					"name":                 dbName,
+					"cluster_size":         "PS-10",
+					"allow_data_branching": "true",
+					"automatic_migrations": "true",
+					"insights_raw_queries": "true",
+					"migration_framework":  "rails",
+				}),
+				ConfigPlanChecks: checkExpectUpdate("planetscale_database.test"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("planetscale_database.test", "migration_framework", "rails"),
+				),
+			},
+
+			// Disable data branching
+			{
+				Config: testAccDatabaseResourceConfigTemplate(map[string]string{
+					"organization":         testAccOrg,
+					"name":                 dbName,
+					"cluster_size":         "PS-10",
+					"allow_data_branching": "false",
+				}),
+				ConfigPlanChecks: checkExpectUpdate("planetscale_database.test"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("planetscale_database.test", "allow_data_branching", "false"),
+				),
+			},
+
+			// Disable automatic migrations
+			{
+				Config: testAccDatabaseResourceConfigTemplate(map[string]string{
+					"organization":         testAccOrg,
+					"name":                 dbName,
+					"cluster_size":         "PS-10",
+					"allow_data_branching": "false",
+					"automatic_migrations": "false",
+				}),
+				ConfigPlanChecks: checkExpectUpdate("planetscale_database.test"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("planetscale_database.test", "automatic_migrations", "false"),
+				),
+			},
+			// Disable insights raw queries
+			{
+				Config: testAccDatabaseResourceConfigTemplate(map[string]string{
+					"organization":         testAccOrg,
+					"name":                 dbName,
+					"cluster_size":         "PS-10",
+					"allow_data_branching": "false",
+					"automatic_migrations": "false",
+					"insights_raw_queries": "false",
+				}),
+				ConfigPlanChecks: checkExpectUpdate("planetscale_database.test"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("planetscale_database.test", "insights_raw_queries", "false"),
+				),
+			},
+
+			// Change cluster_size should trigger a recreate.
+			// TODO: Update this test when the API supports in-place cluster_size changes: https://github.com/planetscale/terraform-provider-planetscale/issues/107
+			{
+				Config: testAccDatabaseResourceConfigTemplate(map[string]string{
+					"organization":         testAccOrg,
+					"name":                 dbName,
+					"cluster_size":         "PS-10",
+					"allow_data_branching": "false",
+					"automatic_migrations": "false",
+					"insights_raw_queries": "false",
+				}),
+				// Save test time by only checking the plan, not actually recreating, we know destroy+create works:
+				PlanOnly:         true,
+				ConfigPlanChecks: checkExpectUpdate("planetscale_database.test"),
+			},
 		},
 	})
 }
@@ -61,7 +180,11 @@ func TestAccDatabaseResource_OutOfBandDelete(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
-				Config: testAccDatabaseResourceConfig(dbName, "PS-10"),
+				Config: testAccDatabaseResourceConfigTemplate(map[string]string{
+					"organization": testAccOrg,
+					"name":         dbName,
+					"cluster_size": "PS-10",
+				}),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("planetscale_database.test", "production_branches_count", "1"),
 					resource.TestCheckResourceAttr("planetscale_database.test", "default_branch", "main"),
@@ -85,12 +208,23 @@ func TestAccDatabaseResource_OutOfBandDelete(t *testing.T) {
 	})
 }
 
-func testAccDatabaseResourceConfig(dbName string, clusterSize string) string {
-	return fmt.Sprintf(`
+func testAccDatabaseResourceConfigTemplate(settings map[string]string) string {
+	const tmpl = `
 resource "planetscale_database" "test" {
-  organization   = "%s"
-  name           = "%s"
-  cluster_size   = "%s"
+    organization  = "{{.organization}}"
+    name          = "{{.name}}"
+    cluster_size  = "{{.cluster_size}}"
+    {{if .allow_data_branching}}allow_data_branching = {{.allow_data_branching}}{{end}}
+    {{if .automatic_migrations}}automatic_migrations = {{.automatic_migrations}}{{end}}
+    {{if .insights_raw_queries}}insights_raw_queries = {{.insights_raw_queries}}{{end}}
+    {{if .migration_framework}}migration_framework = "{{.migration_framework}}"{{end}}
 }
-`, testAccOrg, dbName, clusterSize)
+`
+	t := template.Must(template.New("config").Parse(tmpl))
+	var buf bytes.Buffer
+	err := t.Execute(&buf, settings)
+	if err != nil {
+		return ""
+	}
+	return buf.String()
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -67,7 +67,7 @@ Known limitations:
 - When using service tokens (recommended), ensure the token has the ` + "`create_databases`" + ` organization-level permission. This allows terraform to create new databases and automatically grants the token all other permissions on the databases created by the token.`,
 		Attributes: map[string]schema.Attribute{
 			"endpoint": schema.StringAttribute{
-				MarkdownDescription: "If set, points the API client to a different endpoint than `https:://api.planetscale.com/v1`.",
+				MarkdownDescription: "If set, points the API client to a different endpoint than `https://api.planetscale.com/v1`.",
 				Optional:            true,
 			},
 			"access_token": schema.StringAttribute{

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -92,7 +92,7 @@ func checkOneOf(values ...string) resource.CheckResourceAttrWithFunc {
 	}
 }
 
-func checkExpectUpdate(resourceName string) resource.ConfigPlanChecks {
+func checkExpectUpdate(resourceName string) resource.ConfigPlanChecks { //nolint:unparam
 	return resource.ConfigPlanChecks{
 		PreApply: []plancheck.PlanCheck{
 			plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
@@ -100,7 +100,7 @@ func checkExpectUpdate(resourceName string) resource.ConfigPlanChecks {
 	}
 }
 
-func checkExpectRecreate(resourceName string) resource.ConfigPlanChecks {
+func checkExpectRecreate(resourceName string) resource.ConfigPlanChecks { //nolint:unused
 	return resource.ConfigPlanChecks{
 		PreApply: []plancheck.PlanCheck{
 			plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionReplace),

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/planetscale/terraform-provider-planetscale/internal/client/planetscale"
 	"golang.org/x/oauth2"
 )
@@ -88,6 +89,22 @@ func checkOneOf(values ...string) resource.CheckResourceAttrWithFunc {
 			}
 		}
 		return fmt.Errorf("value %q is not one of %s", value, strings.Join(values, ", "))
+	}
+}
+
+func checkExpectUpdate(resourceName string) resource.ConfigPlanChecks {
+	return resource.ConfigPlanChecks{
+		PreApply: []plancheck.PlanCheck{
+			plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+		},
+	}
+}
+
+func checkExpectRecreate(resourceName string) resource.ConfigPlanChecks {
+	return resource.ConfigPlanChecks{
+		PreApply: []plancheck.PlanCheck{
+			plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionReplace),
+		},
 	}
 }
 

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -92,6 +92,8 @@ func checkOneOf(values ...string) resource.CheckResourceAttrWithFunc {
 	}
 }
 
+// checkExpectUpdate is a helper function for resource.TestStep/ConfigPlanChecks
+// to assert that the plan should updated the resource in place.
 func checkExpectUpdate(resourceName string) resource.ConfigPlanChecks { //nolint:unparam
 	return resource.ConfigPlanChecks{
 		PreApply: []plancheck.PlanCheck{
@@ -100,6 +102,8 @@ func checkExpectUpdate(resourceName string) resource.ConfigPlanChecks { //nolint
 	}
 }
 
+// checkExpectRecreate is a helper function for resource.TestStep/ConfigPlanChecks
+// to assert that the plan should recreate the resource.
 func checkExpectRecreate(resourceName string) resource.ConfigPlanChecks { //nolint:unused
 	return resource.ConfigPlanChecks{
 		PreApply: []plancheck.PlanCheck{


### PR DESCRIPTION
- mark `cluster_size` as required
- mark `cluster_size` as requiring recreate (destroy+create), pending: https://github.com/planetscale/terraform-provider-planetscale/issues/107
- fix `issues_count` marked as a changeable param, it is readonly
- fix `multiple_admins_required_for_deletion` marked as a changeable param, it is readonly
- fix `plan` marked as a changeable param, it is readonly
- when `automatic_migrations` is `true`, `migration_framework` and `migration_table_name` must be set
- refactor `planetscale_database` tests to include coverage of all changeable params

Also:
- Update goreleaser.yml to address deprecations