### PR TITLE
fix creating planetscale_branch with production = true

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,6 @@
 # Visit https://golangci-lint.run/ for usage documentation
 # and information on other useful linters
 issues:
-  max-per-linter: 0
   max-same-issues: 0
 
 linters:

--- a/internal/provider/branch_resource_test.go
+++ b/internal/provider/branch_resource_test.go
@@ -1,29 +1,36 @@
 package provider
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"testing"
+	"text/template"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestAccBranchResource(t *testing.T) {
-	dbName := acctest.RandomWithPrefix("testacc-branch")
+	dbName := acctest.RandomWithPrefix("testacc-branch-db")
 	branchName := acctest.RandomWithPrefix("branch")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
-			// Create and Read testing
+			// Initial creation with required fields
 			{
-				Config: testAccBranchResourceConfig(dbName, branchName),
+				Config: testAccBranchResourceConfigTemplate(map[string]string{
+					"organization":  testAccOrg,
+					"database":      dbName,
+					"name":          branchName,
+					"parent_branch": "main",
+				}),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("planetscale_branch.test", "name", branchName),
 					resource.TestCheckResourceAttr("planetscale_branch.test", "parent_branch", "main"),
-					resource.TestCheckResourceAttr("planetscale_branch.test", "sharded", "false"),
+					resource.TestCheckResourceAttr("planetscale_branch.test", "production", "false"),
 				),
 			},
 			// ImportState testing
@@ -34,9 +41,54 @@ func TestAccBranchResource(t *testing.T) {
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"updated_at", "schema_last_updated_at"},
 			},
-			// Update and Read testing
-			// TODO: Implement an update test.
-			// Delete testing automatically occurs in TestCase
+			// Update in-place to production branch
+			{
+				Config: testAccBranchResourceConfigTemplate(map[string]string{
+					"organization":  testAccOrg,
+					"database":      dbName,
+					"name":          branchName,
+					"parent_branch": "main",
+					"production":    "true",
+				}),
+				ConfigPlanChecks: checkExpectUpdate("planetscale_branch.test"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("planetscale_branch.test", "production", "true"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccBranchResource_ProductionCreate tests the creation of a branch with
+// the production flag set to true.
+func TestAccBranchResource_ProductionCreate(t *testing.T) {
+	dbName := acctest.RandomWithPrefix("testacc-branch-db")
+	branchName := acctest.RandomWithPrefix("branch")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBranchResourceConfigTemplate(map[string]string{
+					"organization":  testAccOrg,
+					"database":      dbName,
+					"name":          branchName,
+					"parent_branch": "main",
+					"production":    "true",
+				}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("planetscale_branch.test", "production", "true"),
+				),
+			},
+			// ImportState testing
+			{
+				ResourceName:            "planetscale_branch.test",
+				ImportStateId:           fmt.Sprintf("%s,%s,%s", testAccOrg, dbName, branchName),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"updated_at", "schema_last_updated_at"},
+			},
 		},
 	})
 }
@@ -55,14 +107,19 @@ func TestAccBranchResource_OutOfBandDelete(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
-				Config: testAccBranchResourceConfig(dbName, branchName),
+				Config: testAccBranchResourceConfigTemplate(map[string]string{
+					"organization":  testAccOrg,
+					"database":      dbName,
+					"name":          branchName,
+					"parent_branch": "main",
+				}),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("planetscale_branch.test", "name", branchName),
 					resource.TestCheckResourceAttr("planetscale_branch.test", "parent_branch", "main"),
 					resource.TestCheckResourceAttr("planetscale_branch.test", "sharded", "false"),
 				),
 			},
-			// Test out-of-bands deletion of the database should produce a plan to recreate, not error.
+			// Test out-of-bands deletion of the branch should produce a plan to recreate, not error
 			{
 				ResourceName:       "planetscale_branch.test",
 				RefreshState:       true,
@@ -78,20 +135,27 @@ func TestAccBranchResource_OutOfBandDelete(t *testing.T) {
 	})
 }
 
-func testAccBranchResourceConfig(dbName, branchName string) string {
-	return fmt.Sprintf(`
+func testAccBranchResourceConfigTemplate(settings map[string]string) string {
+	const tmpl = `
 resource "planetscale_database" "test" {
-  organization   = "%s"
-  name           = "%s"
-  cluster_size   = "PS-10"
-  default_branch = "main"
+    organization = "{{.organization}}"
+    name         = "{{.database}}"
+    cluster_size = "PS-10"
 }
 
 resource "planetscale_branch" "test" {
-  organization  = "%s"
-  database      = planetscale_database.test.name
-  name          = "%s"
-  parent_branch = planetscale_database.test.default_branch
+    organization  = "{{.organization}}"
+    database      = planetscale_database.test.name
+    name          = "{{.name}}"
+    parent_branch = "{{.parent_branch}}"
+    {{if .production}}production = {{.production}}{{end}}
 }
-  `, testAccOrg, dbName, testAccOrg, branchName)
+`
+	t := template.Must(template.New("config").Parse(tmpl))
+	var buf bytes.Buffer
+	err := t.Execute(&buf, settings)
+	if err != nil {
+		return ""
+	}
+	return buf.String()
 }


### PR DESCRIPTION
Initial creation of a `planetscale_branch` resource with `production = true`
would fail. Fix this by calling the promote branch API during `Create()`.

Also refactored branch acceptance tests to use the newer template pattern
introduced in the `planetscale_branch` resource, and added test cases to
cover `production` attribute usage.