### PR TITLE
Fix golangci-lint v2 deprecations

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,10 +1,12 @@
 # Visit https://golangci-lint.run/ for usage documentation
 # and information on other useful linters
+version: "2"
+
 issues:
   max-same-issues: 0
 
 linters:
-  disable-all: true
+  default: none
   enable:
     - durationcheck
     - errcheck


### PR DESCRIPTION
golangci-lint just released v2 with some breaking changes. This should get `main` back to green builds.