### PR TITLE
ci(gha): add new `generate` workflow

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -1,0 +1,64 @@
+name: generate
+
+on:
+  # Run hourly (12 minutes past the hour as recommended by GitHub)
+  schedule:
+    - cron: '12 * * * *'
+
+  # Allow manual triggering
+  workflow_dispatch:
+
+  pull_request:
+    paths-ignore:
+      - 'README.md'
+      - 'renovate.json5'
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  generate:
+    name: run-generate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
+        with:
+          go-version-file: 'go.mod'
+      - name: Run make generate
+        run: make generate
+
+  # Open/update an issue if a scheduled workflow fails
+  notify:
+    name: open issue on failed workflow
+    needs: generate
+    if: failure() && github.event.pull_request == null
+    runs-on: ubuntu-latest
+    steps:
+      - uses: jayqi/failed-build-issue-action@1a893bbf43ef1c2a8705e2b115cd4f0fe3c5649b # v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          label-name: bot/generate-fail
+
+  # Close any open issues if a workflow succeeds
+  close:
+    name: close issues on successful workflow
+    needs: generate
+    if: success()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Close issue
+        run: |
+          set -eou pipefail
+
+          # Close any existing issues with the generate-fail label
+          for num in $(gh issue list -l "bot/generate-fail" --state open --json number --jq '.[].number'); do
+            gh issue close "$num" -c "Auto-closing on subsequent successful build" -r completed
+          done
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -15,7 +15,6 @@ on:
 
 permissions:
   contents: read
-  issues: write
 
 jobs:
   generate:
@@ -35,6 +34,9 @@ jobs:
   notify:
     name: open issue on failed workflow
     needs: generate
+    permissions:
+      contents: read
+      issues: write
     if: failure() && github.event.pull_request == null
     runs-on: ubuntu-latest
     steps:
@@ -47,11 +49,16 @@ jobs:
   close:
     name: close issues on successful workflow
     needs: generate
+    permissions:
+      contents: read
+      issues: write
     if: success()
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - name: Close issue
         run: |
           set -eou pipefail

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -27,6 +27,7 @@ jobs:
       - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
           go-version-file: 'go.mod'
+      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
       - name: Run make generate
         run: make generate
 

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -8,11 +8,6 @@ on:
   # Allow manual triggering
   workflow_dispatch:
 
-  pull_request:
-    paths-ignore:
-      - 'README.md'
-      - 'renovate.json5'
-
 permissions:
   contents: read
 


### PR DESCRIPTION
Run hourly, on PRs, and via manual trigger.

runs `make generate` to regenerate the PS client from the public openapi spec and alert (open issue) on any errors.

closes #123 