### PR TITLE
Map query safety parameters to their property

### DIFF
--- a/internal/provider/postgresbranchrole_resource_sdk.go
+++ b/internal/provider/postgresbranchrole_resource_sdk.go
@@ -182,10 +182,24 @@ func (r *PostgresBranchRoleResourceModel) ToOperationsCreateRoleRequestBody(ctx 
 	for _, inheritedRolesItem := range r.InheritedRoles {
 		inheritedRoles = append(inheritedRoles, operations.InheritedRoleRequest(inheritedRolesItem.ValueString()))
 	}
+	requireWhereOnDelete := new(string)
+	if !r.QuerySafetySettings.RequireWhereOnDelete.IsUnknown() && !r.QuerySafetySettings.RequireWhereOnDelete.IsNull() {
+		*requireWhereOnDelete = r.QuerySafetySettings.RequireWhereOnDelete.undefined
+	} else {
+		requireWhereOnDelete = nil
+	}
+	requireWhereOnUpdate := new(string)
+	if !r.QuerySafetySettings.RequireWhereOnUpdate.IsUnknown() && !r.QuerySafetySettings.RequireWhereOnUpdate.IsNull() {
+		*requireWhereOnUpdate = r.QuerySafetySettings.RequireWhereOnUpdate.undefined
+	} else {
+		requireWhereOnUpdate = nil
+	}
 	out := operations.CreateRoleRequestBody{
-		Name:           name,
-		TTL:            ttl,
-		InheritedRoles: inheritedRoles,
+		Name:                 name,
+		TTL:                  ttl,
+		InheritedRoles:       inheritedRoles,
+		RequireWhereOnDelete: requireWhereOnDelete,
+		RequireWhereOnUpdate: requireWhereOnUpdate,
 	}
 
 	return &out, diags
@@ -307,8 +321,22 @@ func (r *PostgresBranchRoleResourceModel) ToOperationsUpdateRoleRequestBody(ctx 
 	} else {
 		name = nil
 	}
+	requireWhereOnDelete := new(string)
+	if !r.QuerySafetySettings.RequireWhereOnDelete.IsUnknown() && !r.QuerySafetySettings.RequireWhereOnDelete.IsNull() {
+		*requireWhereOnDelete = r.QuerySafetySettings.RequireWhereOnDelete.undefined
+	} else {
+		requireWhereOnDelete = nil
+	}
+	requireWhereOnUpdate := new(string)
+	if !r.QuerySafetySettings.RequireWhereOnUpdate.IsUnknown() && !r.QuerySafetySettings.RequireWhereOnUpdate.IsNull() {
+		*requireWhereOnUpdate = r.QuerySafetySettings.RequireWhereOnUpdate.undefined
+	} else {
+		requireWhereOnUpdate = nil
+	}
 	out := operations.UpdateRoleRequestBody{
-		Name: name,
+		Name:                 name,
+		RequireWhereOnDelete: requireWhereOnDelete,
+		RequireWhereOnUpdate: requireWhereOnUpdate,
 	}
 
 	return &out, diags

--- a/internal/sdk/models/operations/createrole.go
+++ b/internal/sdk/models/operations/createrole.go
@@ -75,6 +75,10 @@ type CreateRoleRequestBody struct {
 	TTL *int64 `json:"ttl,omitzero"`
 	// Roles to inherit from
 	InheritedRoles []InheritedRoleRequest `json:"inherited_roles,omitzero"`
+	// Require WHERE clause on DELETE statements
+	RequireWhereOnDelete *string `json:"require_where_on_delete,omitzero"`
+	// Require WHERE clause on UPDATE statements
+	RequireWhereOnUpdate *string `json:"require_where_on_update,omitzero"`
 }
 
 func (c CreateRoleRequestBody) MarshalJSON() ([]byte, error) {
@@ -107,6 +111,20 @@ func (c *CreateRoleRequestBody) GetInheritedRoles() []InheritedRoleRequest {
 		return nil
 	}
 	return c.InheritedRoles
+}
+
+func (c *CreateRoleRequestBody) GetRequireWhereOnDelete() *string {
+	if c == nil {
+		return nil
+	}
+	return c.RequireWhereOnDelete
+}
+
+func (c *CreateRoleRequestBody) GetRequireWhereOnUpdate() *string {
+	if c == nil {
+		return nil
+	}
+	return c.RequireWhereOnUpdate
 }
 
 type CreateRoleRequest struct {

--- a/internal/sdk/models/operations/updaterole.go
+++ b/internal/sdk/models/operations/updaterole.go
@@ -12,6 +12,10 @@ import (
 type UpdateRoleRequestBody struct {
 	// The new name of the role
 	Name *string `json:"name,omitzero"`
+	// Require WHERE clause on DELETE statements
+	RequireWhereOnDelete *string `json:"require_where_on_delete,omitzero"`
+	// Require WHERE clause on UPDATE statements
+	RequireWhereOnUpdate *string `json:"require_where_on_update,omitzero"`
 }
 
 func (u *UpdateRoleRequestBody) GetName() *string {
@@ -19,6 +23,20 @@ func (u *UpdateRoleRequestBody) GetName() *string {
 		return nil
 	}
 	return u.Name
+}
+
+func (u *UpdateRoleRequestBody) GetRequireWhereOnDelete() *string {
+	if u == nil {
+		return nil
+	}
+	return u.RequireWhereOnDelete
+}
+
+func (u *UpdateRoleRequestBody) GetRequireWhereOnUpdate() *string {
+	if u == nil {
+		return nil
+	}
+	return u.RequireWhereOnUpdate
 }
 
 type UpdateRoleRequest struct {

--- a/schemas/out.openapi.yaml
+++ b/schemas/out.openapi.yaml
@@ -2108,6 +2108,14 @@ paths:
                       - postgres
                   description: Roles to inherit from
                   format: set
+                require_where_on_delete:
+                  type: string
+                  description: Require WHERE clause on DELETE statements
+                  x-speakeasy-match: query_safety_settings.require_where_on_delete
+                require_where_on_update:
+                  type: string
+                  description: Require WHERE clause on UPDATE statements
+                  x-speakeasy-match: query_safety_settings.require_where_on_update
               additionalProperties: false
       responses:
         "200":
@@ -2580,6 +2588,14 @@ paths:
                 name:
                   type: string
                   description: The new name of the role
+                require_where_on_delete:
+                  type: string
+                  description: Require WHERE clause on DELETE statements
+                  x-speakeasy-match: query_safety_settings.require_where_on_delete
+                require_where_on_update:
+                  type: string
+                  description: Require WHERE clause on UPDATE statements
+                  x-speakeasy-match: query_safety_settings.require_where_on_update
               additionalProperties: false
       responses:
         "200":

--- a/schemas/overlay-terraform-postgres-branch-role.yaml
+++ b/schemas/overlay-terraform-postgres-branch-role.yaml
@@ -99,12 +99,15 @@ actions:
     update:
       x-speakeasy-ignore: true
 
-  # These need to map to the nested query_safety_settings property
   - target: $.paths["/organizations/{organization}/databases/{database}/branches/{branch}/roles"].post.requestBody.content['application/json'].schema.properties.require_where_on_delete
-    remove: true
+    update:
+      x-speakeasy-match: query_safety_settings.require_where_on_delete
   - target: $.paths["/organizations/{organization}/databases/{database}/branches/{branch}/roles/{id}"].patch.requestBody.content['application/json'].schema.properties.require_where_on_delete
-    remove: true
+    update:
+      x-speakeasy-match: query_safety_settings.require_where_on_delete
   - target: $.paths["/organizations/{organization}/databases/{database}/branches/{branch}/roles"].post.requestBody.content['application/json'].schema.properties.require_where_on_update
-    remove: true
+    update:
+      x-speakeasy-match: query_safety_settings.require_where_on_update
   - target: $.paths["/organizations/{organization}/databases/{database}/branches/{branch}/roles/{id}"].patch.requestBody.content['application/json'].schema.properties.require_where_on_update
-    remove: true
+    update:
+      x-speakeasy-match: query_safety_settings.require_where_on_update


### PR DESCRIPTION
For the [Postgres role APIs](https://planetscale.com/docs/api/reference/create_role), `require_where_on_delete` and `require_where_on_update` are top-level parameters in the request body that map to the nested [`query_safety_settings`](https://planetscale.com/docs/api/reference/create_role#response-query-safety-settings) object in the response.

