### PR TITLE
Trim acceptance test matrix

### DIFF
--- a/.github/workflows/test-extensive.yml
+++ b/.github/workflows/test-extensive.yml
@@ -58,9 +58,6 @@ jobs:
       matrix:
         terraform:
           - "1.5.7" # Last MPL version - https://github.com/hashicorp/terraform/blob/v1.5.7/LICENSE
-          - "1.9.*"
-          - "1.10.*"
-          - "1.11.*"
           - latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -89,9 +86,6 @@ jobs:
       fail-fast: false
       matrix:
         tofu:
-          - "1.9.*"
-          - "1.10.*"
-          - "1.11.*"
           - latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
The acceptance test matrix in `test-extensive.yml` runs against 5 Terraform versions and 4 OpenTofu versions on every PR, ~9 jobs of ~10–15 minutes each that all hit the production PlanetScale API and create real cluster resources. The intermediate versions catch a narrow class of regression — most version-specific behavior is abstracted by `terraform-plugin-framework` — and the cost in CI time and `planetscale-terraform-testing` quota is meaningful.

This trims the matrix to the three signals that actually matter:
- `terraform 1.5.7` — last MPL-licensed release, hard requirement for some user environments.
- `terraform latest` — early signal on the bleeding edge.
- `opentofu latest` — protocol-compat coverage for the fork.

If a regression is reported pinned to a specific intermediate version we can re-add it temporarily.