### PR TITLE
chore(codeowners): rename @planetscale/infra to @planetscale/platform

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @planetscale/surfaces @planetscale/infra
+* @planetscale/surfaces @planetscale/platform


### PR DESCRIPTION
Renames the `@planetscale/infra` team handle to `@planetscale/platform` in CODEOWNERS.

Applied across all repos where `@planetscale/infra` appears in CODEOWNERS (search via `gh search code`).