### PR TITLE
Create release for `v1.1.0`

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -5,8 +5,8 @@ management:
   docVersion: v1
   speakeasyVersion: 1.763.1
   generationVersion: 2.884.4
-  releaseVersion: 1.0.0
-  configChecksum: 1fcc848f8b2354c4b771e9bf9f613ae2
+  releaseVersion: 1.1.0
+  configChecksum: 03f848e9c0c17f874cc7ad0bbf7f5b55
 persistentEdits:
   generation_id: 60e31278-cdaa-4542-9c58-f63a48b53d1a
   pristine_commit_hash: 0f48b87acc4799dd3898ffc3569dccdf1e31fb15
@@ -79,7 +79,7 @@ trackedFiles:
     pristine_git_object: 7ab5ffb6c575475282a87565f6ee7c8403074b63
   examples/provider/provider.tf:
     id: 954e955c0240
-    last_write_checksum: sha1:f008ea5aeb85e5d9365c8061ced10ebdb48b83d1
+    last_write_checksum: sha1:0ad0f7a48b453ed2885b147299b3bcf6122ff4e5
     pristine_git_object: 66664be2637146405147ef9bc663d13b453ce3f8
   examples/resources/planetscale_postgres_branch/import-by-string-id.tf:
     id: 84ea6cbb56ce
@@ -719,7 +719,7 @@ trackedFiles:
     pristine_git_object: 482aa982b4571ec54f57707879032cc00c8fe24e
   internal/sdk/planetscale.go:
     id: e52bf6906e91
-    last_write_checksum: sha1:f2eb4d2d052880a3f7dbb98d68f38ed57450b3f3
+    last_write_checksum: sha1:e157ce0e691f81e5e15a3876c90abc2cbdbd960a
     pristine_git_object: edd5a04397c8e2e1faa37b1515cc10715653813e
   internal/sdk/polling/config.go:
     id: e14a17f21f84

--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -32,7 +32,7 @@ generation:
     generateNewTests: true
     skipResponseBodyAssertions: false
 terraform:
-  version: 1.0.0
+  version: 1.1.0
   additionalActions: []
   additionalDataSources: []
   additionalDependencies:

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ terraform {
   required_providers {
     planetscale = {
       source  = "planetscale/planetscale"
-      version = "1.0.0"
+      version = "1.1.0"
     }
   }
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ terraform {
   required_providers {
     planetscale = {
       source  = "planetscale/planetscale"
-      version = "1.0.0"
+      version = "1.1.0"
     }
   }
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     planetscale = {
       source  = "planetscale/planetscale"
-      version = "1.0.0"
+      version = "1.1.0"
     }
   }
 }

--- a/internal/sdk/planetscale.go
+++ b/internal/sdk/planetscale.go
@@ -141,9 +141,9 @@ func WithTimeout(timeout time.Duration) SDKOption {
 // New creates a new instance of the SDK with the provided options
 func New(opts ...SDKOption) *PlanetScale {
 	sdk := &PlanetScale{
-		SDKVersion: "1.0.0",
+		SDKVersion: "1.1.0",
 		sdkConfiguration: config.SDKConfiguration{
-			UserAgent:  "speakeasy-sdk/terraform 1.0.0 2.884.4 v1 github.com/planetscale/terraform-provider-planetscale/internal/sdk",
+			UserAgent:  "speakeasy-sdk/terraform 1.1.0 2.884.4 v1 github.com/planetscale/terraform-provider-planetscale/internal/sdk",
 			ServerList: ServerList,
 		},
 		hooks: hooks.New(),


### PR DESCRIPTION
New features:
- https://github.com/planetscale/terraform-provider-planetscale/pull/265

No breaking changes. Creating and deleting databases use the existing `planetscale_postgres_branch` and `planetscale_vitess_branch` resources. Makes `cluster_size` writable for `planetscale_vitess_branch` (additive).