### PR TITLE
Speed up Postgres branch acceptance tests

### DIFF
--- a/internal/provider/postgresbranch_resource_test.go
+++ b/internal/provider/postgresbranch_resource_test.go
@@ -20,7 +20,6 @@ func TestAccPostgresBranchResource_Lifecycle(t *testing.T) {
 	branchNameRenamed := randomWithPrefix("test-renamed")
 	resourceAddress := "planetscale_postgres_branch.test"
 	clusterSize := "PS_10_AWS_ARM"
-	newClusterSize := "PS_5_AWS_ARM"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
@@ -63,18 +62,13 @@ func TestAccPostgresBranchResource_Lifecycle(t *testing.T) {
 					"organization":  config.StringVariable(testAccOrg),
 					"database_name": config.StringVariable(databaseName),
 					"branch_name":   config.StringVariable(branchNameRenamed),
-					"cluster_size":  config.StringVariable(newClusterSize),
+					"cluster_size":  config.StringVariable(clusterSize),
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						resourceAddress,
 						tfjsonpath.New("name"),
 						knownvalue.StringExact(branchNameRenamed),
-					),
-					statecheck.ExpectKnownValue(
-						resourceAddress,
-						tfjsonpath.New("cluster_size"),
-						knownvalue.StringExact(newClusterSize),
 					),
 				},
 			},
@@ -84,7 +78,7 @@ func TestAccPostgresBranchResource_Lifecycle(t *testing.T) {
 					"organization":  config.StringVariable(testAccOrg),
 					"database_name": config.StringVariable(databaseName),
 					"branch_name":   config.StringVariable(branchNameRenamed),
-					"cluster_size":  config.StringVariable(newClusterSize),
+					"cluster_size":  config.StringVariable(clusterSize),
 				},
 				ResourceName: resourceAddress,
 				ImportState:  true,

--- a/internal/provider/postgresbranch_resource_test.go
+++ b/internal/provider/postgresbranch_resource_test.go
@@ -19,7 +19,7 @@ func TestAccPostgresBranchResource_Lifecycle(t *testing.T) {
 	branchNameOriginal := randomWithPrefix("test")
 	branchNameRenamed := randomWithPrefix("test-renamed")
 	resourceAddress := "planetscale_postgres_branch.test"
-	clusterSize := "PS_10_AWS_ARM"
+	clusterSize := "PS_DEV_AWS_ARM"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
@@ -104,7 +104,7 @@ func TestAccPostgresBranchResource_CreatesAndDeletesDatabase(t *testing.T) {
 	databaseName := randomWithPrefix("testacc-pg-lifecycle")
 	branchName := "main"
 	resourceAddress := "planetscale_postgres_branch.test"
-	clusterSize := "PS_10_AWS_ARM"
+	clusterSize := "PS_DEV_AWS_ARM"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },


### PR DESCRIPTION
## Context

`TestAccPostgresBranchResource_Lifecycle` and `TestAccPostgresBranchResource_CreatesAndDeletesDatabase` repeatedly time out the 30m per-job limit in `test-extensive.yml`. Recent examples:

- [run 26479290031](https://github.com/planetscale/terraform-provider-planetscale/actions/runs/26479290031)
- [run 25939069077](https://github.com/planetscale/terraform-provider-planetscale/actions/runs/25939069077)
- [run 25886331470](https://github.com/planetscale/terraform-provider-planetscale/actions/runs/25886331470)
- [run 25743925040](https://github.com/planetscale/terraform-provider-planetscale/actions/runs/25743925040)

The tests do multiple slow provisioning ops against the shared `testacc-postgres` fixture, and CI fans out three concurrent `make testacc` invocations on the same org (TF 1.5.7, TF latest, OpenTofu latest). The cluster-provisioning queue saturates and the tests run out of time.

## Changes

1. Use `PS_DEV_AWS_ARM` (smallest cluster size) in both tests.
2. Simplify step 2 of `_Lifecycle` to only rename the branch, dropping the `PS_10_AWS_ARM` → `PS_5_AWS_ARM` resize.

## Result

Full `integration-*` job runs in ~7-8 minutes on [this PR's run](https://github.com/planetscale/terraform-provider-planetscale/actions/runs/26541941089), down from hitting the 30m timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)