### PR TITLE
Add lifecycle tests for backups

### DIFF
--- a/.github/workflows/test-extensive.yml
+++ b/.github/workflows/test-extensive.yml
@@ -48,7 +48,7 @@ jobs:
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
 
   test-terraform:
-    name: integration-terraform
+    name: integration-terraform (${{ matrix.terraform }})
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -82,7 +82,7 @@ jobs:
         timeout-minutes: 30
 
   test-tofu:
-    name: integration-tofu
+    name: integration-tofu (${{ matrix.tofu }})
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 60

--- a/.github/workflows/test-extensive.yml
+++ b/.github/workflows/test-extensive.yml
@@ -56,9 +56,11 @@ jobs:
       fail-fast: false
       max-parallel: 2
       matrix:
-        terraform:
-          - "1.5.7" # Last MPL version - https://github.com/hashicorp/terraform/blob/v1.5.7/LICENSE
-          - latest
+        include:
+          - terraform: "1.5.7" # Last MPL version - https://github.com/hashicorp/terraform/blob/v1.5.7/LICENSE
+            branch: terraform-157
+          - terraform: latest
+            branch: terraform-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -74,6 +76,9 @@ jobs:
         env:
           PLANETSCALE_SERVICE_TOKEN_ID: ${{ secrets.PLANETSCALE_SERVICE_TOKEN_ID }}
           PLANETSCALE_SERVICE_TOKEN: ${{ secrets.PLANETSCALE_SERVICE_TOKEN }}
+          # Dedicated backup branch so concurrent jobs don't contend for the
+          # API's single in-flight manual backup per branch.
+          PLANETSCALE_TEST_BRANCH: ${{ matrix.branch }}
         timeout-minutes: 30
 
   test-tofu:
@@ -85,8 +90,9 @@ jobs:
       max-parallel: 2
       fail-fast: false
       matrix:
-        tofu:
-          - latest
+        include:
+          - tofu: latest
+            branch: tofu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -102,4 +108,7 @@ jobs:
         env:
           PLANETSCALE_SERVICE_TOKEN_ID: ${{ secrets.PLANETSCALE_SERVICE_TOKEN_ID }}
           PLANETSCALE_SERVICE_TOKEN: ${{ secrets.PLANETSCALE_SERVICE_TOKEN }}
+          # Dedicated backup branch so concurrent jobs don't contend for the
+          # API's single in-flight manual backup per branch.
+          PLANETSCALE_TEST_BRANCH: ${{ matrix.branch }}
         timeout-minutes: 30

--- a/internal/provider/postgresbranchbackup_resource_test.go
+++ b/internal/provider/postgresbranchbackup_resource_test.go
@@ -81,6 +81,7 @@ func TestAccPostgresBranchBackupResource_Lifecycle(t *testing.T) {
 					return string(jsonBytes), err
 				},
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"retention_value", "retention_unit"},
 			},
 		},
 	})

--- a/internal/provider/postgresbranchbackup_resource_test.go
+++ b/internal/provider/postgresbranchbackup_resource_test.go
@@ -1,0 +1,87 @@
+package provider
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+func TestAccPostgresBranchBackupResource_Lifecycle(t *testing.T) {
+	t.Parallel()
+
+	databaseName := "testacc-postgres"
+	branchName := "main"
+	backupName := randomWithPrefix("test-backup")
+	resourceAddress := "planetscale_postgres_branch_backup.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders(),
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.TestNameDirectory(),
+				ConfigVariables: config.Variables{
+					"organization":  config.StringVariable(testAccOrg),
+					"database_name": config.StringVariable(databaseName),
+					"branch_name":   config.StringVariable(branchName),
+					"backup_name":   config.StringVariable(backupName),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						resourceAddress,
+						tfjsonpath.New("id"),
+						knownvalue.NotNull(),
+					),
+					statecheck.ExpectKnownValue(
+						resourceAddress,
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(backupName),
+					),
+					statecheck.ExpectKnownValue(
+						resourceAddress,
+						tfjsonpath.New("retention_value"),
+						knownvalue.Int64Exact(1),
+					),
+					statecheck.ExpectKnownValue(
+						resourceAddress,
+						tfjsonpath.New("retention_unit"),
+						knownvalue.StringExact("day"),
+					),
+					statecheck.ExpectKnownValue(
+						resourceAddress,
+						tfjsonpath.New("state"),
+						knownvalue.NotNull(),
+					),
+				},
+			},
+			{
+				ConfigDirectory: config.TestNameDirectory(),
+				ConfigVariables: config.Variables{
+					"organization":  config.StringVariable(testAccOrg),
+					"database_name": config.StringVariable(databaseName),
+					"branch_name":   config.StringVariable(branchName),
+					"backup_name":   config.StringVariable(backupName),
+				},
+				ResourceName: resourceAddress,
+				ImportState:  true,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					rs := s.RootModule().Resources[resourceAddress]
+					jsonBytes, err := json.Marshal(map[string]string{
+						"branch":       rs.Primary.Attributes["branch"],
+						"database":     rs.Primary.Attributes["database"],
+						"id":           rs.Primary.Attributes["id"],
+						"organization": rs.Primary.Attributes["organization"],
+					})
+					return string(jsonBytes), err
+				},
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/internal/provider/postgresbranchbackup_resource_test.go
+++ b/internal/provider/postgresbranchbackup_resource_test.go
@@ -16,7 +16,7 @@ func TestAccPostgresBranchBackupResource_Lifecycle(t *testing.T) {
 	t.Parallel()
 
 	databaseName := "testacc-postgres"
-	branchName := "main"
+	branchName := testAccBackupBranch()
 	backupName := randomWithPrefix("test-backup")
 	resourceAddress := "planetscale_postgres_branch_backup.test"
 

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -35,3 +35,10 @@ func testAccPreCheck(t *testing.T) {
 func randomWithPrefix(prefix string) string {
 	return fmt.Sprintf("%s-%d", prefix, rand.Intn(1000000))
 }
+
+func testAccBackupBranch() string {
+	if branch := os.Getenv("PLANETSCALE_TEST_BRANCH"); branch != "" {
+		return branch
+	}
+	return "main"
+}

--- a/internal/provider/testdata/TestAccPostgresBranchBackupResource_Lifecycle/main.tf
+++ b/internal/provider/testdata/TestAccPostgresBranchBackupResource_Lifecycle/main.tf
@@ -1,0 +1,24 @@
+variable "organization" {
+  type = string
+}
+
+variable "database_name" {
+  type = string
+}
+
+variable "branch_name" {
+  type = string
+}
+
+variable "backup_name" {
+  type = string
+}
+
+resource "planetscale_postgres_branch_backup" "test" {
+  organization    = var.organization
+  database        = var.database_name
+  branch          = var.branch_name
+  name            = var.backup_name
+  retention_value = 1
+  retention_unit  = "day"
+}

--- a/internal/provider/testdata/TestAccVitessBranchBackupResource_Lifecycle/main.tf
+++ b/internal/provider/testdata/TestAccVitessBranchBackupResource_Lifecycle/main.tf
@@ -1,0 +1,24 @@
+variable "organization" {
+  type = string
+}
+
+variable "database_name" {
+  type = string
+}
+
+variable "branch_name" {
+  type = string
+}
+
+variable "backup_name" {
+  type = string
+}
+
+resource "planetscale_vitess_branch_backup" "test" {
+  organization    = var.organization
+  database        = var.database_name
+  branch          = var.branch_name
+  name            = var.backup_name
+  retention_value = 1
+  retention_unit  = "day"
+}

--- a/internal/provider/vitessbranchbackup_resource_test.go
+++ b/internal/provider/vitessbranchbackup_resource_test.go
@@ -1,0 +1,87 @@
+package provider
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+func TestAccVitessBranchBackupResource_Lifecycle(t *testing.T) {
+	t.Parallel()
+
+	databaseName := "testacc-vitess"
+	branchName := "main"
+	backupName := randomWithPrefix("test-backup")
+	resourceAddress := "planetscale_vitess_branch_backup.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders(),
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.TestNameDirectory(),
+				ConfigVariables: config.Variables{
+					"organization":  config.StringVariable(testAccOrg),
+					"database_name": config.StringVariable(databaseName),
+					"branch_name":   config.StringVariable(branchName),
+					"backup_name":   config.StringVariable(backupName),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						resourceAddress,
+						tfjsonpath.New("id"),
+						knownvalue.NotNull(),
+					),
+					statecheck.ExpectKnownValue(
+						resourceAddress,
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(backupName),
+					),
+					statecheck.ExpectKnownValue(
+						resourceAddress,
+						tfjsonpath.New("retention_value"),
+						knownvalue.Int64Exact(1),
+					),
+					statecheck.ExpectKnownValue(
+						resourceAddress,
+						tfjsonpath.New("retention_unit"),
+						knownvalue.StringExact("day"),
+					),
+					statecheck.ExpectKnownValue(
+						resourceAddress,
+						tfjsonpath.New("state"),
+						knownvalue.NotNull(),
+					),
+				},
+			},
+			{
+				ConfigDirectory: config.TestNameDirectory(),
+				ConfigVariables: config.Variables{
+					"organization":  config.StringVariable(testAccOrg),
+					"database_name": config.StringVariable(databaseName),
+					"branch_name":   config.StringVariable(branchName),
+					"backup_name":   config.StringVariable(backupName),
+				},
+				ResourceName: resourceAddress,
+				ImportState:  true,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					rs := s.RootModule().Resources[resourceAddress]
+					jsonBytes, err := json.Marshal(map[string]string{
+						"branch":       rs.Primary.Attributes["branch"],
+						"database":     rs.Primary.Attributes["database"],
+						"id":           rs.Primary.Attributes["id"],
+						"organization": rs.Primary.Attributes["organization"],
+					})
+					return string(jsonBytes), err
+				},
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/internal/provider/vitessbranchbackup_resource_test.go
+++ b/internal/provider/vitessbranchbackup_resource_test.go
@@ -81,6 +81,7 @@ func TestAccVitessBranchBackupResource_Lifecycle(t *testing.T) {
 					return string(jsonBytes), err
 				},
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"retention_value", "retention_unit"},
 			},
 		},
 	})

--- a/internal/provider/vitessbranchbackup_resource_test.go
+++ b/internal/provider/vitessbranchbackup_resource_test.go
@@ -16,7 +16,7 @@ func TestAccVitessBranchBackupResource_Lifecycle(t *testing.T) {
 	t.Parallel()
 
 	databaseName := "testacc-vitess"
-	branchName := "main"
+	branchName := testAccBackupBranch()
 	backupName := randomWithPrefix("test-backup")
 	resourceAddress := "planetscale_vitess_branch_backup.test"
 

--- a/script/sweep
+++ b/script/sweep
@@ -25,7 +25,10 @@ pscale database list --org "$ORG" --format json |
 
 for dbname in testacc-vitess testacc-postgres; do
   pscale branch list "$dbname" --org "$ORG" --format json |
-    jq -r '.[] | select(.name != "main") | .name' |
+    jq -r '.[] | select(.name != "main"
+      and .name != "terraform-157"
+      and .name != "terraform-latest"
+      and .name != "tofu-latest") | .name' |
     while read -r branch; do
       if [ "$DRY_RUN" = "true" ]; then
         echo "[DRY RUN] Would delete branch: $dbname/$branch"


### PR DESCRIPTION
This introduces lifecycle tests for the backup resources introduced in #285, following a similar pattern to our existing role & password lifecycle tests. An existing branch & database is used to avoid needing to spin up a new database. Our test databases are relatively small, so creating a backup shouldn't take too long.