### PR TITLE
Create release for `v1.2.0`

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -5,8 +5,8 @@ management:
   docVersion: v1
   speakeasyVersion: 1.778.0
   generationVersion: 2.904.2
-  releaseVersion: 1.1.0
-  configChecksum: 806ec28226461e1024bbc1f470263808
+  releaseVersion: 1.2.0
+  configChecksum: a040d6b3c94b8f38e3344b49a4fa2da8
 persistentEdits:
   generation_id: 60e31278-cdaa-4542-9c58-f63a48b53d1a
   pristine_commit_hash: 0f48b87acc4799dd3898ffc3569dccdf1e31fb15
@@ -92,7 +92,7 @@ trackedFiles:
     pristine_git_object: 7ab5ffb6c575475282a87565f6ee7c8403074b63
   examples/provider/provider.tf:
     id: 954e955c0240
-    last_write_checksum: sha1:0ad0f7a48b453ed2885b147299b3bcf6122ff4e5
+    last_write_checksum: sha1:2fa615a3a2d088affa8e29f6436459482bb09034
     pristine_git_object: 66664be2637146405147ef9bc663d13b453ce3f8
   examples/resources/planetscale_postgres_backup_policy/import-by-string-id.tf:
     last_write_checksum: sha1:898e41884b689e8b155d6fbdaef64ac5487d6217
@@ -864,7 +864,7 @@ trackedFiles:
     pristine_git_object: 482aa982b4571ec54f57707879032cc00c8fe24e
   internal/sdk/planetscale.go:
     id: e52bf6906e91
-    last_write_checksum: sha1:50e5dd6b5dcc23da5b39fe4b3a1aff3ef75d1740
+    last_write_checksum: sha1:db26862435f816f178d03bb5699a5171e2fc4b72
     pristine_git_object: edd5a04397c8e2e1faa37b1515cc10715653813e
   internal/sdk/polling/config.go:
     id: e14a17f21f84

--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -32,7 +32,7 @@ generation:
     generateNewTests: true
     skipResponseBodyAssertions: false
 terraform:
-  version: 1.1.0
+  version: 1.2.0
   additionalActions: []
   additionalDataSources: []
   additionalDependencies: []

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ terraform {
   required_providers {
     planetscale = {
       source  = "planetscale/planetscale"
-      version = "1.1.0"
+      version = "1.2.0"
     }
   }
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ terraform {
   required_providers {
     planetscale = {
       source  = "planetscale/planetscale"
-      version = "1.1.0"
+      version = "1.2.0"
     }
   }
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     planetscale = {
       source  = "planetscale/planetscale"
-      version = "1.1.0"
+      version = "1.2.0"
     }
   }
 }

--- a/internal/sdk/planetscale.go
+++ b/internal/sdk/planetscale.go
@@ -147,9 +147,9 @@ func WithTimeout(timeout time.Duration) SDKOption {
 // New creates a new instance of the SDK with the provided options
 func New(opts ...SDKOption) *PlanetScale {
 	sdk := &PlanetScale{
-		SDKVersion: "1.1.0",
+		SDKVersion: "1.2.0",
 		sdkConfiguration: config.SDKConfiguration{
-			UserAgent:  "speakeasy-sdk/terraform 1.1.0 2.904.2 v1 github.com/planetscale/terraform-provider-planetscale/internal/sdk",
+			UserAgent:  "speakeasy-sdk/terraform 1.2.0 2.904.2 v1 github.com/planetscale/terraform-provider-planetscale/internal/sdk",
 			ServerList: ServerList,
 		},
 		hooks: hooks.New(),


### PR DESCRIPTION
New features since `v1.1.0`:
- Managed branch backups — create/delete backup resources (#283, #285) and branch backup data sources (#281)
- Backup policy resources and data sources (#279, #280)
- Configurable Postgres parameters and extensions (#288)

No breaking changes. The backups and backup-policy surface is entirely net-new, so nothing in the previously released schema changes. This is a minor version bump (`1.1.0` → `1.2.0`), generated via Speakeasy (`speakeasy run --set-version 1.2.0`).

Merging this, then pushing the `v1.2.0` tag, triggers the `release.yml` workflow (goreleaser + GPG signing) and the Terraform Registry picks up the new version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)