### PR TITLE
Create release for `v1.3.0`

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -5,8 +5,8 @@ management:
   docVersion: v1
   speakeasyVersion: 1.778.0
   generationVersion: 2.904.2
-  releaseVersion: 1.2.0
-  configChecksum: a040d6b3c94b8f38e3344b49a4fa2da8
+  releaseVersion: 1.3.0
+  configChecksum: af35ba1da5635c40db8cdedf8b0c7963
 persistentEdits:
   generation_id: 60e31278-cdaa-4542-9c58-f63a48b53d1a
   pristine_commit_hash: 0f48b87acc4799dd3898ffc3569dccdf1e31fb15
@@ -94,7 +94,7 @@ trackedFiles:
     pristine_git_object: 7ab5ffb6c575475282a87565f6ee7c8403074b63
   examples/provider/provider.tf:
     id: 954e955c0240
-    last_write_checksum: sha1:2fa615a3a2d088affa8e29f6436459482bb09034
+    last_write_checksum: sha1:01e4a44a39a27d8b971f3a1da930556e664ae0f4
     pristine_git_object: 66664be2637146405147ef9bc663d13b453ce3f8
   examples/resources/planetscale_postgres_backup_policy/import-by-string-id.tf:
     last_write_checksum: sha1:898e41884b689e8b155d6fbdaef64ac5487d6217
@@ -892,7 +892,7 @@ trackedFiles:
     pristine_git_object: 482aa982b4571ec54f57707879032cc00c8fe24e
   internal/sdk/planetscale.go:
     id: e52bf6906e91
-    last_write_checksum: sha1:db26862435f816f178d03bb5699a5171e2fc4b72
+    last_write_checksum: sha1:e83bf4e7c163818ccb42f0a4a70964030a428535
     pristine_git_object: edd5a04397c8e2e1faa37b1515cc10715653813e
   internal/sdk/polling/config.go:
     id: e14a17f21f84

--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -32,7 +32,7 @@ generation:
     generateNewTests: true
     skipResponseBodyAssertions: false
 terraform:
-  version: 1.2.0
+  version: 1.3.0
   additionalActions: []
   additionalDataSources: []
   additionalDependencies: []

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ terraform {
   required_providers {
     planetscale = {
       source  = "planetscale/planetscale"
-      version = "1.2.0"
+      version = "1.3.0"
     }
   }
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     planetscale = {
       source  = "planetscale/planetscale"
-      version = "1.2.0"
+      version = "1.3.0"
     }
   }
 }

--- a/internal/sdk/planetscale.go
+++ b/internal/sdk/planetscale.go
@@ -147,9 +147,9 @@ func WithTimeout(timeout time.Duration) SDKOption {
 // New creates a new instance of the SDK with the provided options
 func New(opts ...SDKOption) *PlanetScale {
 	sdk := &PlanetScale{
-		SDKVersion: "1.2.0",
+		SDKVersion: "1.3.0",
 		sdkConfiguration: config.SDKConfiguration{
-			UserAgent:  "speakeasy-sdk/terraform 1.2.0 2.904.2 v1 github.com/planetscale/terraform-provider-planetscale/internal/sdk",
+			UserAgent:  "speakeasy-sdk/terraform 1.3.0 2.904.2 v1 github.com/planetscale/terraform-provider-planetscale/internal/sdk",
 			ServerList: ServerList,
 		},
 		hooks: hooks.New(),


### PR DESCRIPTION
`v1.3.0` introduces the `planetscale_postgres_redacted_branch_role` resource, which mirrors `planetscale_postgres_branch_role` but ensures the plaintext password is not included in Terraform state.

- #295