### PR TITLE
Allow Intel metal cluster sizes for Postgres

### DIFF
--- a/internal/provider/postgresbranch_resource_schema_test.go
+++ b/internal/provider/postgresbranch_resource_schema_test.go
@@ -35,6 +35,7 @@ func TestPostgresBranchResource_ClusterSizeValidation(t *testing.T) {
 		{value: "PS_5_GCP_ARM", valid: true},
 		{value: "PS_DEV_AWS_X86", valid: true},
 		{value: "M1_10_AWS_AMD_D_METAL_10", valid: true},
+		{value: "M7_5760_AWS_INTEL_D_METAL_45000", valid: true},
 		{value: "M4_160_D_METAL_460", valid: false},
 		{value: "M_160_GCP_AMD_D_METAL_742", valid: false},
 		{value: "M_160_GCP_INTEL_D_METAL_742", valid: false},

--- a/internal/validators/stringvalidators/cluster_size_validator.go
+++ b/internal/validators/stringvalidators/cluster_size_validator.go
@@ -16,7 +16,7 @@ const (
 	qualifiedPSPattern    = `PS_` + psSizePattern + `_(?:AWS|GCP)_(?:ARM|X86|AMD)`
 	vitessPSPattern       = `PS_` + psSizePattern
 	instancePSPattern     = `PS_(?:(?:AWS|GCP)_)?[A-Z][0-9][A-Z0-9]*(?:_[A-Z0-9]+)+`
-	qualifiedMetalPattern = `M[0-9]+_[0-9]+_(?:AWS|GCP)_(?:ARM|X86|AMD)_D_METAL_[0-9]+`
+	qualifiedMetalPattern = `M[0-9]+_[0-9]+_(?:AWS|GCP)_(?:ARM|X86|AMD|INTEL)_D_METAL_[0-9]+`
 	vitessMetalPattern    = `M[0-9]*_[0-9]+(?:_(?:AWS|GCP)_(?:AMD|INTEL|X86))?_D_METAL_[0-9]+`
 )
 


### PR DESCRIPTION
Creating a Postgres database with an Intel metal cluster size such as `M7_5760_AWS_INTEL_D_METAL_45000` fails plan-time validation with "is not a valid cluster_size", even though the API lists these as valid PostgreSQL sizes. The `cluster_size` pattern only accepts ARM, X86, and AMD in the architecture segment, so every M6 and M7 Intel metal SKU is rejected. The Vitess pattern already accepts INTEL.

This adds INTEL to the qualified metal pattern and a test case for a real Intel metal SKU.