### PR TITLE
Warn when removed Postgres branch parameters will reset to defaults

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -1,7 +1,7 @@
 lockVersion: 2.0.0
 id: 156e2223-c8d0-4591-922d-3e4c474de609
 management:
-  docChecksum: 7eddddc65b478f7c9c5d7fd35226c543
+  docChecksum: 6e691a392cf84fbd91ce75a5f6602eac
   docVersion: v1
   speakeasyVersion: 1.778.0
   generationVersion: 2.904.2
@@ -308,7 +308,7 @@ trackedFiles:
     pristine_git_object: ce4a668f6f884d6898c67aae59a7df6d67cd89e4
   internal/provider/postgresbranch_resource.go:
     id: b66a7c0510bb
-    last_write_checksum: sha1:86bfcc6d0bcded31931a5a055f271a7eab073dd8
+    last_write_checksum: sha1:530fedc3d505c40553cb06578775f1e5472428c7
     pristine_git_object: 592d4c15815e79e1711aa2bc6a6ede61aec55eee
   internal/provider/postgresbranch_resource_sdk.go:
     id: dd6faad04ef1

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -2,8 +2,8 @@ speakeasyVersion: 1.778.0
 sources:
     PlanetScale API:
         sourceNamespace: planet-scale-api
-        sourceRevisionDigest: sha256:baac245976e08b5ab561fc11b1eea7a716ca5f76729179dbe2385ea0473627b5
-        sourceBlobDigest: sha256:1f63171a8984d38cc586db56d6d7990f27aaeafe72c5dd202d908fbc8f6c13ab
+        sourceRevisionDigest: sha256:2be821cba5fded99a0dbfedb8fce237de8573d4acdd0ee2083257826cca56bab
+        sourceBlobDigest: sha256:0425c7eaea0e81fe5a51de56928598cb7742a7736e9cdc7c82c5f5da5a32e654
         tags:
             - latest
             - v1
@@ -11,8 +11,8 @@ targets:
     planetscale:
         source: PlanetScale API
         sourceNamespace: planet-scale-api
-        sourceRevisionDigest: sha256:baac245976e08b5ab561fc11b1eea7a716ca5f76729179dbe2385ea0473627b5
-        sourceBlobDigest: sha256:1f63171a8984d38cc586db56d6d7990f27aaeafe72c5dd202d908fbc8f6c13ab
+        sourceRevisionDigest: sha256:2be821cba5fded99a0dbfedb8fce237de8573d4acdd0ee2083257826cca56bab
+        sourceBlobDigest: sha256:0425c7eaea0e81fe5a51de56928598cb7742a7736e9cdc7c82c5f5da5a32e654
 workflow:
     workflowVersion: 1.0.0
     speakeasyVersion: 1.778.0

--- a/internal/planmodifiers/mapplanmodifier/warn_on_removed_parameters.go
+++ b/internal/planmodifiers/mapplanmodifier/warn_on_removed_parameters.go
@@ -1,0 +1,94 @@
+package mapplanmodifier
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var _ planmodifier.Map = MapWarnOnRemovedParametersPlanModifier{}
+
+type MapWarnOnRemovedParametersPlanModifier struct{}
+
+// Description describes the plan modification in plain text formatting.
+func (v MapWarnOnRemovedParametersPlanModifier) Description(_ context.Context) string {
+	return "Warns when previously configured parameters are removed from the configuration, since removed parameters are reset to their defaults."
+}
+
+// MarkdownDescription describes the plan modification in Markdown formatting.
+func (v MapWarnOnRemovedParametersPlanModifier) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+// PlanModifyMap performs the plan modification.
+func (v MapWarnOnRemovedParametersPlanModifier) PlanModifyMap(ctx context.Context, req planmodifier.MapRequest, resp *planmodifier.MapResponse) {
+	// No prior state to compare against (resource creation).
+	if req.StateValue.IsNull() || req.StateValue.IsUnknown() {
+		return
+	}
+	// Config null means the whole attribute was removed (or this is a destroy
+	// plan). The attribute is Computed+Optional, so Terraform keeps the prior
+	// state value in the plan and nothing is reset. Config unknown means we
+	// can't know what will be sent.
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+
+	var state map[string]map[string]string
+	if diags := req.StateValue.ElementsAs(ctx, &state, false); diags.HasError() {
+		return
+	}
+
+	// Only key presence matters, and nested config values may be unknown, so
+	// walk the elements directly instead of using ElementsAs. A nil key set
+	// marks a namespace whose contents are unknown.
+	configKeys := map[string]map[string]struct{}{}
+	for namespace, value := range req.ConfigValue.Elements() {
+		inner, ok := value.(types.Map)
+		if !ok || inner.IsUnknown() {
+			configKeys[namespace] = nil
+			continue
+		}
+		keys := map[string]struct{}{}
+		if !inner.IsNull() {
+			for key := range inner.Elements() {
+				keys[key] = struct{}{}
+			}
+		}
+		configKeys[namespace] = keys
+	}
+
+	var removed []string
+	for namespace, params := range state {
+		keys, namespaceInConfig := configKeys[namespace]
+		if namespaceInConfig && keys == nil {
+			continue
+		}
+		for key, value := range params {
+			if _, ok := keys[key]; !ok {
+				removed = append(removed, fmt.Sprintf("%s.%s (currently %q)", namespace, key, value))
+			}
+		}
+	}
+	if len(removed) == 0 {
+		return
+	}
+	sort.Strings(removed)
+
+	resp.Diagnostics.AddAttributeWarning(
+		req.Path,
+		"Removed parameters will be reset to their defaults",
+		"The following parameters were removed from the configuration, so on apply each "+
+			"will be reset to its default value:\n\n  - "+
+			strings.Join(removed, "\n  - ")+
+			"\n\nTo keep a parameter at its current value, add it back to the parameters attribute.",
+	)
+}
+
+func WarnOnRemovedParameters() planmodifier.Map {
+	return MapWarnOnRemovedParametersPlanModifier{}
+}

--- a/internal/planmodifiers/mapplanmodifier/warn_on_removed_parameters_test.go
+++ b/internal/planmodifiers/mapplanmodifier/warn_on_removed_parameters_test.go
@@ -1,0 +1,134 @@
+package mapplanmodifier
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/require"
+)
+
+var parametersElemType = types.MapType{ElemType: types.StringType}
+
+func parametersValue(t *testing.T, params map[string]map[string]string) types.Map {
+	t.Helper()
+
+	outer := map[string]attr.Value{}
+	for namespace, kv := range params {
+		inner := map[string]attr.Value{}
+		for k, v := range kv {
+			inner[k] = types.StringValue(v)
+		}
+		outer[namespace] = types.MapValueMust(types.StringType, inner)
+	}
+	return types.MapValueMust(parametersElemType, outer)
+}
+
+func TestWarnOnRemovedParameters(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		state        types.Map
+		config       types.Map
+		wantInDetail []string
+	}{
+		"create with null state": {
+			state:  types.MapNull(parametersElemType),
+			config: parametersValue(t, map[string]map[string]string{"pgconf": {"max_connections": "200"}}),
+		},
+		"no changes": {
+			state:  parametersValue(t, map[string]map[string]string{"pgconf": {"max_connections": "200"}}),
+			config: parametersValue(t, map[string]map[string]string{"pgconf": {"max_connections": "200"}}),
+		},
+		"value changed": {
+			state:  parametersValue(t, map[string]map[string]string{"pgconf": {"max_connections": "200"}}),
+			config: parametersValue(t, map[string]map[string]string{"pgconf": {"max_connections": "300"}}),
+		},
+		"one key removed": {
+			state: parametersValue(t, map[string]map[string]string{
+				"pgconf": {"max_connections": "200", "statement_timeout": "5s"},
+			}),
+			config: parametersValue(t, map[string]map[string]string{
+				"pgconf": {"max_connections": "200"},
+			}),
+			wantInDetail: []string{`pgconf.statement_timeout (currently "5s")`},
+		},
+		"whole namespace removed": {
+			state: parametersValue(t, map[string]map[string]string{
+				"pgconf":    {"max_connections": "200"},
+				"pgbouncer": {"pool_mode": "transaction"},
+			}),
+			config: parametersValue(t, map[string]map[string]string{
+				"pgconf": {"max_connections": "200"},
+			}),
+			wantInDetail: []string{`pgbouncer.pool_mode (currently "transaction")`},
+		},
+		"removals across namespaces are sorted": {
+			state: parametersValue(t, map[string]map[string]string{
+				"pgconf":  {"max_connections": "200"},
+				"patroni": {"loop_wait": "10"},
+			}),
+			config: parametersValue(t, map[string]map[string]string{}),
+			wantInDetail: []string{
+				"- patroni.loop_wait (currently \"10\")\n  - pgconf.max_connections (currently \"200\")",
+			},
+		},
+		"key added only": {
+			state: parametersValue(t, map[string]map[string]string{
+				"pgconf": {"max_connections": "200"},
+			}),
+			config: parametersValue(t, map[string]map[string]string{
+				"pgconf": {"max_connections": "200", "statement_timeout": "5s"},
+			}),
+		},
+		"whole attribute removed": {
+			state:  parametersValue(t, map[string]map[string]string{"pgconf": {"max_connections": "200"}}),
+			config: types.MapNull(parametersElemType),
+		},
+		"unknown config": {
+			state:  parametersValue(t, map[string]map[string]string{"pgconf": {"max_connections": "200"}}),
+			config: types.MapUnknown(parametersElemType),
+		},
+		"unknown namespace in config": {
+			state: parametersValue(t, map[string]map[string]string{"pgconf": {"max_connections": "200"}}),
+			config: types.MapValueMust(parametersElemType, map[string]attr.Value{
+				"pgconf": types.MapUnknown(types.StringType),
+			}),
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			req := planmodifier.MapRequest{
+				Path:        path.Root("parameters"),
+				StateValue:  tc.state,
+				ConfigValue: tc.config,
+				PlanValue:   tc.config,
+			}
+			resp := &planmodifier.MapResponse{PlanValue: req.PlanValue}
+			WarnOnRemovedParameters().PlanModifyMap(context.Background(), req, resp)
+
+			require.Equal(t, req.PlanValue, resp.PlanValue)
+			require.False(t, resp.Diagnostics.HasError())
+
+			if len(tc.wantInDetail) == 0 {
+				require.Empty(t, resp.Diagnostics)
+				return
+			}
+
+			require.Len(t, resp.Diagnostics, 1)
+			d := resp.Diagnostics[0]
+			require.Equal(t, diag.SeverityWarning, d.Severity())
+			require.Contains(t, d.Summary(), "reset to their defaults")
+			for _, want := range tc.wantInDetail {
+				require.Contains(t, d.Detail(), want)
+			}
+		})
+	}
+}

--- a/internal/provider/postgresbranch_resource.go
+++ b/internal/provider/postgresbranch_resource.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	custom_mapplanmodifier "github.com/planetscale/terraform-provider-planetscale/internal/planmodifiers/mapplanmodifier"
 	speakeasy_stringplanmodifier "github.com/planetscale/terraform-provider-planetscale/internal/planmodifiers/stringplanmodifier"
 	tfTypes "github.com/planetscale/terraform-provider-planetscale/internal/provider/types"
 	"github.com/planetscale/terraform-provider-planetscale/internal/sdk"
@@ -127,6 +128,9 @@ func (r *PostgresBranchResource) Schema(ctx context.Context, req resource.Schema
 			"parameters": schema.MapAttribute{
 				Computed: true,
 				Optional: true,
+				PlanModifiers: []planmodifier.Map{
+					custom_mapplanmodifier.WarnOnRemovedParameters(),
+				},
 				ElementType: types.MapType{
 					ElemType: types.StringType,
 				},

--- a/internal/provider/postgresbranch_resource_schema_test.go
+++ b/internal/provider/postgresbranch_resource_schema_test.go
@@ -12,6 +12,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestPostgresBranchResource_ParametersPlanModifiers(t *testing.T) {
+	t.Parallel()
+
+	r := NewPostgresBranchResource()
+	var schemaResp resource.SchemaResponse
+	r.Schema(context.Background(), resource.SchemaRequest{}, &schemaResp)
+
+	attr, ok := schemaResp.Schema.Attributes["parameters"]
+	require.True(t, ok)
+
+	parametersAttr, ok := attr.(schema.MapAttribute)
+	require.True(t, ok)
+
+	require.NotEmpty(t, parametersAttr.PlanModifiers)
+}
+
 func TestPostgresBranchResource_ClusterSizeValidation(t *testing.T) {
 	t.Parallel()
 

--- a/schemas/out.openapi.yaml
+++ b/schemas/out.openapi.yaml
@@ -4457,6 +4457,7 @@ paths:
                     type: object
                     additionalProperties:
                       type: string
+                  x-speakeasy-plan-modifiers: WarnOnRemovedParameters
                   description: >-
                     Postgres parameter overrides, nested by namespace (pgconf, pgbouncer, patroni), e.g. { pgconf = { max_connections = "200" } }. Omitted parameters are reset to their defaults.
       responses:

--- a/schemas/overlay-terraform-postgres-branch.yaml
+++ b/schemas/overlay-terraform-postgres-branch.yaml
@@ -221,6 +221,7 @@ actions:
                         type: object
                         additionalProperties:
                           type: string
+                      x-speakeasy-plan-modifiers: WarnOnRemovedParameters
                       description: >-
                         Postgres parameter overrides, nested by namespace (pgconf, pgbouncer,
                         patroni), e.g. { pgconf = { max_connections = "200" } }. Omitted


### PR DESCRIPTION
When a customer removes a parameter from the `parameters` block of a `planetscale_postgres_branch` resource, applying resets that parameter to its PlanetScale default. The plan output only showed the value going to null, so the reset surprised customers.

This adds a plan modifier to the `parameters` attribute through the `x-speakeasy-plan-modifiers` extension. `terraform plan` now shows a warning that lists each removed parameter with its current value and explains that each one resets to its default on apply. Removing the whole `parameters` block keeps the prior values and does not warn.

<img width="2106" height="1436" alt="CleanShot 2026-07-13 at 12 18 31@2x" src="https://github.com/user-attachments/assets/1e0dda6e-d64b-48fb-91f1-3f18b8c50984" />