### PR TITLE
Detect drift when Postgres parameters are reset to their defaults

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -1,7 +1,7 @@
 lockVersion: 2.0.0
 id: 156e2223-c8d0-4591-922d-3e4c474de609
 management:
-  docChecksum: 10e4021648a1ef1d3083e6345fcd8318
+  docChecksum: 246f9a4df8119edd5055b8a49bc3961f
   docVersion: v1
   speakeasyVersion: 1.778.0
   generationVersion: 2.904.2
@@ -309,22 +309,22 @@ trackedFiles:
   internal/provider/postgresbouncer_data_source.go:
     last_write_checksum: sha1:0e422965792ec8e5aeb7f681594c5d28fcf44045
   internal/provider/postgresbouncer_data_source_sdk.go:
-    last_write_checksum: sha1:dc381ef983b28e9a46e263039424b0fafa55c9d6
+    last_write_checksum: sha1:f6563fc96104113c10f24a616a1389d11eb4192c
   internal/provider/postgresbouncer_resource.go:
     last_write_checksum: sha1:efbb13331ead2990b228c276755f8c1e02b4abbe
   internal/provider/postgresbouncer_resource_sdk.go:
-    last_write_checksum: sha1:f7dbc06384e4803de17f119ec0cdb21277159a23
+    last_write_checksum: sha1:441589c303bfb14c1245ef0f4b18074898bbdefd
   internal/provider/postgresbouncers_data_source.go:
     last_write_checksum: sha1:51650afce36b2ecbb53aac7a17a3071a3a9ec4e2
   internal/provider/postgresbouncers_data_source_sdk.go:
-    last_write_checksum: sha1:8a147347841e9536e0fb8159084d72334021dc81
+    last_write_checksum: sha1:e5e6c0701cbb77ff5006f49b1d3a169899a55a2a
   internal/provider/postgresbranch_data_source.go:
     id: 3d4847eac64b
     last_write_checksum: sha1:97bf2e2fc190cc8d1e204c5b77fa2c01bdfbf7f5
     pristine_git_object: 8c62e876b56d5f981678f2556da600430340d765
   internal/provider/postgresbranch_data_source_sdk.go:
     id: 65aff8470b2f
-    last_write_checksum: sha1:df224656eaff938b90b2e56e430233eecc95bb8a
+    last_write_checksum: sha1:852e68497fc0df4408dbe6c23548444eb69ba340
     pristine_git_object: ce4a668f6f884d6898c67aae59a7df6d67cd89e4
   internal/provider/postgresbranch_resource.go:
     id: b66a7c0510bb
@@ -332,7 +332,7 @@ trackedFiles:
     pristine_git_object: 592d4c15815e79e1711aa2bc6a6ede61aec55eee
   internal/provider/postgresbranch_resource_sdk.go:
     id: dd6faad04ef1
-    last_write_checksum: sha1:f8fa6ce30f7e59f4ff62a23d2533f5bdca5fb1eb
+    last_write_checksum: sha1:9bb12d98d4203a015aae7e26427cb62c4747e814
     pristine_git_object: 1654632ec76584a3f646c2394baac915f1ddbf84
   internal/provider/postgresbranchbackup_data_source.go:
     last_write_checksum: sha1:4c0ee7ef46349c97f7d6e737abfcd244e19ff36b
@@ -767,7 +767,7 @@ trackedFiles:
   internal/sdk/models/operations/applypostgresbranchterraformchanges.go:
     last_write_checksum: sha1:c9bbd023d1a0e3c31f08f4cf36f2bab9f6772789
   internal/sdk/models/operations/createbouncer.go:
-    last_write_checksum: sha1:8920720802df600a0dbb4a40e8ea8d2a901285b3
+    last_write_checksum: sha1:28447e5823039c8b1045038779b30f602daffaad
   internal/sdk/models/operations/createpassword.go:
     id: 9f61008ec29b
     last_write_checksum: sha1:d8c34bf4df1751c4cb4f66a799750bc2255c4478
@@ -823,7 +823,7 @@ trackedFiles:
   internal/sdk/models/operations/deletevitessbranchbackup.go:
     last_write_checksum: sha1:baebdbea776e7f3cd696030cf0ffd4a734b36514
   internal/sdk/models/operations/getbouncer.go:
-    last_write_checksum: sha1:edc929db95e26478dad61d60016f13c5aa1cfba2
+    last_write_checksum: sha1:0ac00c65d053802d68aeacb2446a53953917350a
   internal/sdk/models/operations/getbranchchangerequest.go:
     last_write_checksum: sha1:211d4629f1a9fc65e1c8f96177ec3e3a867d27b9
   internal/sdk/models/operations/getorganization.go:
@@ -865,7 +865,7 @@ trackedFiles:
     last_write_checksum: sha1:45a55d593fcac53c27cd9aa32589ca44e4508172
     pristine_git_object: be96b47a67d020a8a2b0d5198abfd4db9b7db3bf
   internal/sdk/models/operations/listbouncers.go:
-    last_write_checksum: sha1:ea67e074b1f9ee63522a70a9ea262bcdd3232e01
+    last_write_checksum: sha1:c2bca7fbf77953de5331ee1b62940545b3818a04
   internal/sdk/models/operations/listdatabases.go:
     id: 9a615ba562a7
     last_write_checksum: sha1:b10f3738fb608e4d068f712d17a605a88fbdfdcc

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -2,8 +2,8 @@ speakeasyVersion: 1.778.0
 sources:
     PlanetScale API:
         sourceNamespace: planet-scale-api
-        sourceRevisionDigest: sha256:6748e0195389e973566a05018dd5b5fe021200fa2d2901effa8b75d8d98592cc
-        sourceBlobDigest: sha256:768e94695eab40acecbf548e67aef508475e4f82ce7198b9e852b63a55420857
+        sourceRevisionDigest: sha256:5986178d80daa52826f44d48c42f7302c2a34817c6458ce90f1de62ce0b8e0ad
+        sourceBlobDigest: sha256:c62cca064ec0a936f3cbd7903e41720348aa14693c78d7bd2698153078b1b8b7
         tags:
             - latest
             - v1
@@ -11,8 +11,8 @@ targets:
     planetscale:
         source: PlanetScale API
         sourceNamespace: planet-scale-api
-        sourceRevisionDigest: sha256:6748e0195389e973566a05018dd5b5fe021200fa2d2901effa8b75d8d98592cc
-        sourceBlobDigest: sha256:768e94695eab40acecbf548e67aef508475e4f82ce7198b9e852b63a55420857
+        sourceRevisionDigest: sha256:5986178d80daa52826f44d48c42f7302c2a34817c6458ce90f1de62ce0b8e0ad
+        sourceBlobDigest: sha256:c62cca064ec0a936f3cbd7903e41720348aa14693c78d7bd2698153078b1b8b7
 workflow:
     workflowVersion: 1.0.0
     speakeasyVersion: 1.778.0

--- a/internal/provider/postgresbouncer_data_source_sdk.go
+++ b/internal/provider/postgresbouncer_data_source_sdk.go
@@ -19,7 +19,7 @@ func (r *PostgresBouncerDataSourceModel) RefreshFromOperationsGetBouncerResponse
 		r.BouncerSize = types.StringPointerValue(resp.BouncerSize)
 		r.ID = types.StringValue(resp.ID)
 		r.Name = types.StringValue(resp.Name)
-		if len(resp.Parameters) > 0 {
+		if resp.Parameters != nil {
 			r.Parameters = make(map[string]map[string]types.String, len(resp.Parameters))
 			for parametersKey, parametersValue := range resp.Parameters {
 				var parametersResult map[string]types.String

--- a/internal/provider/postgresbouncer_resource_sdk.go
+++ b/internal/provider/postgresbouncer_resource_sdk.go
@@ -30,7 +30,7 @@ func (r *PostgresBouncerResourceModel) RefreshFromOperationsCreateBouncerRespons
 		r.BouncerSize = types.StringPointerValue(resp.BouncerSize)
 		r.ID = types.StringValue(resp.ID)
 		r.Name = types.StringValue(resp.Name)
-		if len(resp.Parameters) > 0 {
+		if resp.Parameters != nil {
 			r.Parameters = make(map[string]map[string]types.String, len(resp.Parameters))
 			for parametersKey, parametersValue := range resp.Parameters {
 				var parametersResult map[string]types.String
@@ -60,7 +60,7 @@ func (r *PostgresBouncerResourceModel) RefreshFromOperationsGetBouncerResponseBo
 		r.BouncerSize = types.StringPointerValue(resp.BouncerSize)
 		r.ID = types.StringValue(resp.ID)
 		r.Name = types.StringValue(resp.Name)
-		if len(resp.Parameters) > 0 {
+		if resp.Parameters != nil {
 			r.Parameters = make(map[string]map[string]types.String, len(resp.Parameters))
 			for parametersKey, parametersValue := range resp.Parameters {
 				var parametersResult map[string]types.String
@@ -129,16 +129,19 @@ func (r *PostgresBouncerResourceModel) ToOperationsApplyPostgresBouncerTerraform
 	} else {
 		replicasPerCell = nil
 	}
-	parameters := make(map[string]map[string]string)
-	for parametersKey := range r.Parameters {
-		parametersInst := make(map[string]string)
-		for key := range r.Parameters[parametersKey] {
-			var inst string
-			inst = r.Parameters[parametersKey][key].ValueString()
+	var parameters map[string]map[string]string
+	if r.Parameters != nil {
+		parameters = make(map[string]map[string]string)
+		for parametersKey := range r.Parameters {
+			parametersInst := make(map[string]string)
+			for key := range r.Parameters[parametersKey] {
+				var inst string
+				inst = r.Parameters[parametersKey][key].ValueString()
 
-			parametersInst[key] = inst
+				parametersInst[key] = inst
+			}
+			parameters[parametersKey] = parametersInst
 		}
-		parameters[parametersKey] = parametersInst
 	}
 	out := operations.ApplyPostgresBouncerTerraformChangesRequestBody{
 		BouncerSize:     bouncerSize,

--- a/internal/provider/postgresbouncers_data_source_sdk.go
+++ b/internal/provider/postgresbouncers_data_source_sdk.go
@@ -26,7 +26,7 @@ func (r *PostgresBouncersDataSourceModel) RefreshFromOperationsListBouncersRespo
 			data.BouncerSize = types.StringPointerValue(dataItem.BouncerSize)
 			data.ID = types.StringValue(dataItem.ID)
 			data.Name = types.StringValue(dataItem.Name)
-			if len(dataItem.Parameters) > 0 {
+			if dataItem.Parameters != nil {
 				data.Parameters = make(map[string]map[string]types.String, len(dataItem.Parameters))
 				for parametersKey, parametersValue := range dataItem.Parameters {
 					var parametersResult map[string]types.String

--- a/internal/provider/postgresbranch_data_source_sdk.go
+++ b/internal/provider/postgresbranch_data_source_sdk.go
@@ -24,7 +24,7 @@ func (r *PostgresBranchDataSourceModel) RefreshFromOperationsGetPostgresBranchRe
 		r.HTMLURL = types.StringValue(resp.HTMLURL)
 		r.ID = types.StringValue(resp.ID)
 		r.Name = types.StringValue(resp.Name)
-		if len(resp.Parameters) > 0 {
+		if resp.Parameters != nil {
 			r.Parameters = make(map[string]map[string]types.String, len(resp.Parameters))
 			for parametersKey, parametersValue := range resp.Parameters {
 				var parametersResult map[string]types.String

--- a/internal/provider/postgresbranch_resource_sdk.go
+++ b/internal/provider/postgresbranch_resource_sdk.go
@@ -73,7 +73,7 @@ func (r *PostgresBranchResourceModel) RefreshFromOperationsGetPostgresBranchResp
 		r.HTMLURL = types.StringValue(resp.HTMLURL)
 		r.ID = types.StringValue(resp.ID)
 		r.Name = types.StringValue(resp.Name)
-		if len(resp.Parameters) > 0 {
+		if resp.Parameters != nil {
 			r.Parameters = make(map[string]map[string]types.String, len(resp.Parameters))
 			for parametersKey, parametersValue := range resp.Parameters {
 				var parametersResult map[string]types.String
@@ -166,16 +166,19 @@ func (r *PostgresBranchResourceModel) ToOperationsApplyPostgresBranchTerraformCh
 	} else {
 		clusterSize = nil
 	}
-	parameters := make(map[string]map[string]string)
-	for parametersKey := range r.Parameters {
-		parametersInst := make(map[string]string)
-		for key := range r.Parameters[parametersKey] {
-			var inst string
-			inst = r.Parameters[parametersKey][key].ValueString()
+	var parameters map[string]map[string]string
+	if r.Parameters != nil {
+		parameters = make(map[string]map[string]string)
+		for parametersKey := range r.Parameters {
+			parametersInst := make(map[string]string)
+			for key := range r.Parameters[parametersKey] {
+				var inst string
+				inst = r.Parameters[parametersKey][key].ValueString()
 
-			parametersInst[key] = inst
+				parametersInst[key] = inst
+			}
+			parameters[parametersKey] = parametersInst
 		}
-		parameters[parametersKey] = parametersInst
 	}
 	out := operations.ApplyPostgresBranchTerraformChangesRequestBody{
 		ClusterSize: clusterSize,

--- a/internal/sdk/models/operations/createbouncer.go
+++ b/internal/sdk/models/operations/createbouncer.go
@@ -510,7 +510,7 @@ func (c *CreateBouncerResponseBody) GetBouncerSize() *string {
 
 func (c *CreateBouncerResponseBody) GetParameters() map[string]map[string]string {
 	if c == nil {
-		return map[string]map[string]string{}
+		return nil
 	}
 	return c.Parameters
 }

--- a/internal/sdk/models/operations/getbouncer.go
+++ b/internal/sdk/models/operations/getbouncer.go
@@ -431,7 +431,7 @@ func (g *GetBouncerResponseBody) GetBouncerSize() *string {
 
 func (g *GetBouncerResponseBody) GetParameters() map[string]map[string]string {
 	if g == nil {
-		return map[string]map[string]string{}
+		return nil
 	}
 	return g.Parameters
 }

--- a/internal/sdk/models/operations/listbouncers.go
+++ b/internal/sdk/models/operations/listbouncers.go
@@ -450,7 +450,7 @@ func (l *ListBouncersData) GetBouncerSize() *string {
 
 func (l *ListBouncersData) GetParameters() map[string]map[string]string {
 	if l == nil {
-		return map[string]map[string]string{}
+		return nil
 	}
 	return l.Parameters
 }

--- a/schemas/out.openapi.yaml
+++ b/schemas/out.openapi.yaml
@@ -899,6 +899,7 @@ paths:
                             The bouncer size, e.g. `PGB_5`, `PGB_10`, `PGB_20`, `PGB_40`, `PGB_80`, or `PGB_160`. Defaults to `PGB_5`.
                         parameter_overrides:
                           type: object
+                          nullable: true
                           additionalProperties:
                             type: object
                             additionalProperties:
@@ -1160,6 +1161,7 @@ paths:
                       The bouncer size, e.g. `PGB_5`, `PGB_10`, `PGB_20`, `PGB_40`, `PGB_80`, or `PGB_160`. Defaults to `PGB_5`.
                   parameter_overrides:
                     type: object
+                    nullable: true
                     additionalProperties:
                       type: object
                       additionalProperties:
@@ -1388,6 +1390,7 @@ paths:
                       The bouncer size, e.g. `PGB_5`, `PGB_10`, `PGB_20`, `PGB_40`, `PGB_80`, or `PGB_160`. Defaults to `PGB_5`.
                   parameter_overrides:
                     type: object
+                    nullable: true
                     additionalProperties:
                       type: object
                       additionalProperties:
@@ -4287,6 +4290,7 @@ paths:
                     description: The number of replicas for the branch
                   parameters:
                     type: object
+                    nullable: true
                     additionalProperties:
                       type: object
                       additionalProperties:
@@ -5264,6 +5268,7 @@ paths:
                   description: The size of the cluster. Available sizes can be found using the 'List cluster sizes' endpoint.
                 parameters:
                   type: object
+                  nullable: true
                   additionalProperties:
                     type: object
                     additionalProperties:
@@ -9595,6 +9600,7 @@ paths:
                   description: The number of PgBouncer instances per availability zone. Defaults to 1.
                 parameters:
                   type: object
+                  nullable: true
                   additionalProperties:
                     type: object
                     additionalProperties:

--- a/schemas/overlay-terraform-postgres-bouncer.yaml
+++ b/schemas/overlay-terraform-postgres-bouncer.yaml
@@ -95,6 +95,7 @@ actions:
           `PGB_80`, or `PGB_160`. Defaults to `PGB_5`.
       parameter_overrides:
         type: object
+        nullable: true
         additionalProperties:
           type: object
           additionalProperties:
@@ -122,6 +123,7 @@ actions:
           `PGB_80`, or `PGB_160`. Defaults to `PGB_5`.
       parameter_overrides:
         type: object
+        nullable: true
         additionalProperties:
           type: object
           additionalProperties:
@@ -240,6 +242,7 @@ actions:
                       description: The number of PgBouncer instances per availability zone. Defaults to 1.
                     parameters:
                       type: object
+                      nullable: true
                       additionalProperties:
                         type: object
                         additionalProperties:

--- a/schemas/overlay-terraform-postgres-bouncers.yaml
+++ b/schemas/overlay-terraform-postgres-bouncers.yaml
@@ -52,6 +52,7 @@ actions:
           `PGB_80`, or `PGB_160`. Defaults to `PGB_5`.
       parameter_overrides:
         type: object
+        nullable: true
         additionalProperties:
           type: object
           additionalProperties:

--- a/schemas/overlay-terraform-postgres-branch.yaml
+++ b/schemas/overlay-terraform-postgres-branch.yaml
@@ -73,6 +73,7 @@ actions:
         description: The number of replicas for the branch
       parameters:
         type: object
+        nullable: true
         additionalProperties:
           type: object
           additionalProperties:
@@ -217,6 +218,7 @@ actions:
                       description: The size of the cluster. Available sizes can be found using the 'List cluster sizes' endpoint.
                     parameters:
                       type: object
+                      nullable: true
                       additionalProperties:
                         type: object
                         additionalProperties:


### PR DESCRIPTION
When a user sets a parameter back to its default outside Terraform, the API returns an empty parameters object. The provider treated that the same as no parameters field at all and kept the stale override in state, so terraform plan missed the drift. Cursor Bugbot flagged this on #303, and Speakeasy confirmed the fix.

This marks the parameters properties as nullable in the postgres branch and bouncer overlays. The generated refresh code now distinguishes an empty parameters response from an absent one, clears the overrides from state, and terraform plan shows the drift.