### PR TITLE
Create release for v1.5.1

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -5,8 +5,8 @@ management:
   docVersion: v1
   speakeasyVersion: 1.778.0
   generationVersion: 2.904.2
-  releaseVersion: 1.5.0
-  configChecksum: deb3955e129591c71b0f20c90107a390
+  releaseVersion: 1.5.1
+  configChecksum: dcbd02692b72b0a67c4933843c423056
 persistentEdits:
   generation_id: 60e31278-cdaa-4542-9c58-f63a48b53d1a
   pristine_commit_hash: 0f48b87acc4799dd3898ffc3569dccdf1e31fb15
@@ -98,7 +98,7 @@ trackedFiles:
     pristine_git_object: 7ab5ffb6c575475282a87565f6ee7c8403074b63
   examples/provider/provider.tf:
     id: 954e955c0240
-    last_write_checksum: sha1:c39f47552ce9878505a82da4a0f48913175bc01b
+    last_write_checksum: sha1:36210e634f2d37eb799b0d0c1fc154238736ebc5
     pristine_git_object: 66664be2637146405147ef9bc663d13b453ce3f8
   examples/resources/planetscale_postgres_backup_policy/import-by-string-id.tf:
     last_write_checksum: sha1:898e41884b689e8b155d6fbdaef64ac5487d6217
@@ -932,7 +932,7 @@ trackedFiles:
     pristine_git_object: 482aa982b4571ec54f57707879032cc00c8fe24e
   internal/sdk/planetscale.go:
     id: e52bf6906e91
-    last_write_checksum: sha1:aa0f37a07a9fafc33da2cff54557d71ef66a3d9e
+    last_write_checksum: sha1:4f5e40c3af2fd22227eeaeea934143b8ecd9b2af
     pristine_git_object: edd5a04397c8e2e1faa37b1515cc10715653813e
   internal/sdk/polling/config.go:
     id: e14a17f21f84

--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -32,7 +32,7 @@ generation:
     generateNewTests: true
     skipResponseBodyAssertions: false
 terraform:
-  version: 1.5.0
+  version: 1.5.1
   additionalActions: []
   additionalDataSources: []
   additionalDependencies: []

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ terraform {
   required_providers {
     planetscale = {
       source  = "planetscale/planetscale"
-      version = "1.5.0"
+      version = "1.5.1"
     }
   }
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ terraform {
   required_providers {
     planetscale = {
       source  = "planetscale/planetscale"
-      version = "1.5.0"
+      version = "1.5.1"
     }
   }
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     planetscale = {
       source  = "planetscale/planetscale"
-      version = "1.5.0"
+      version = "1.5.1"
     }
   }
 }

--- a/internal/sdk/planetscale.go
+++ b/internal/sdk/planetscale.go
@@ -150,9 +150,9 @@ func WithTimeout(timeout time.Duration) SDKOption {
 // New creates a new instance of the SDK with the provided options
 func New(opts ...SDKOption) *PlanetScale {
 	sdk := &PlanetScale{
-		SDKVersion: "1.5.0",
+		SDKVersion: "1.5.1",
 		sdkConfiguration: config.SDKConfiguration{
-			UserAgent:  "speakeasy-sdk/terraform 1.5.0 2.904.2 v1 github.com/planetscale/terraform-provider-planetscale/internal/sdk",
+			UserAgent:  "speakeasy-sdk/terraform 1.5.1 2.904.2 v1 github.com/planetscale/terraform-provider-planetscale/internal/sdk",
 			ServerList: ServerList,
 		},
 		hooks: hooks.New(),


### PR DESCRIPTION
Bumps the provider version to **v1.5.1** and regenerates via `make generate`.

Patch release containing two bug fixes since v1.5.0:
- #306 — Detect drift when Postgres parameters are reset to their defaults
- #308 — Read Postgres bouncer state from the terraform-state endpoint (fixes empty bouncer parameters refreshing to null in the data source)

No new resources, data sources, or attributes.

After merging, tag the merge commit as `v1.5.1` and push the tag to trigger the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)