### PR TITLE
ci: run renovate config validator from the pinned docker image

### DIFF
--- a/.github/workflows/validate-renovate.yml
+++ b/.github/workflows/validate-renovate.yml
@@ -3,10 +3,6 @@ name: validate renovate.json
 on:
   pull_request:
 
-env:
-  LOG_LEVEL: debug
-  RENOVATE_VERSION: "44.11.4" # renovate: datasource=npm depName=renovate
-
 permissions:
   contents: read
 
@@ -20,8 +16,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: docker://ghcr.io/renovatebot/renovate:44.13.1@sha256:3e4149122921d530218a4ca809c59636faa668b330e4c9ea7f9ee1e20ea505dd
         with:
-          node-version: 24
-
-      - run: npx --yes --ignore-scripts -p "renovate@${RENOVATE_VERSION}" -- renovate-config-validator renovate.json5
+          entrypoint: renovate-config-validator
+          args: --no-global renovate.json5


### PR DESCRIPTION
**Problem:**

The validate workflow installed renovate from npm
at CI time via `npx`, so a fresh package tree was
resolved and downloaded on every run.

**Solution:**

Run `renovate-config-validator` from the official
renovate image, pinned by tag and digest, as a
docker step. The version is fixed by an immutable
digest, and Renovate keeps the tag+digest updated.
Drops the now unused `setup-node` step and the
`RENOVATE_VERSION`/`LOG_LEVEL` env.

---
_Testing:_ Run in CI
