### PR TITLE
Allow previous backups to complete before integration tests

### DIFF
--- a/internal/provider/postgresbranchbackup_resource_test.go
+++ b/internal/provider/postgresbranchbackup_resource_test.go
@@ -21,7 +21,10 @@ func TestAccPostgresBranchBackupResource_Lifecycle(t *testing.T) {
 	resourceAddress := "planetscale_postgres_branch_backup.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			waitForNoInFlightPostgresBackups(t, databaseName, branchName)
+		},
 		ProtoV6ProviderFactories: testAccProviders(),
 		Steps: []resource.TestStep{
 			{

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -1,13 +1,18 @@
 package provider
 
 import (
+	"context"
 	"fmt"
 	"math/rand"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/planetscale/terraform-provider-planetscale/internal/sdk"
+	"github.com/planetscale/terraform-provider-planetscale/internal/sdk/models/operations"
+	"github.com/planetscale/terraform-provider-planetscale/internal/sdk/models/shared"
 )
 
 const testAccOrg = "planetscale-terraform-testing"
@@ -41,4 +46,98 @@ func testAccBackupBranch() string {
 		return branch
 	}
 	return "main"
+}
+
+const (
+	backupWaitTimeout  = 5 * time.Minute
+	backupWaitInterval = 10 * time.Second
+)
+
+func testAccSDKClient() *sdk.PlanetScale {
+	serverURL := os.Getenv("PLANETSCALE_SERVER_URL")
+	if serverURL == "" {
+		serverURL = "https://api.planetscale.com/v1"
+	}
+	return sdk.New(
+		sdk.WithServerURL(serverURL),
+		sdk.WithSecurity(shared.Security{
+			ServiceToken:   os.Getenv("PLANETSCALE_SERVICE_TOKEN"),
+			ServiceTokenID: os.Getenv("PLANETSCALE_SERVICE_TOKEN_ID"),
+		}),
+	)
+}
+
+func waitForNoInFlightPostgresBackups(t *testing.T, database, branch string) {
+	t.Helper()
+
+	client := testAccSDKClient()
+	waitForNoInFlightBackups(t, branch, func(ctx context.Context) (int, error) {
+		inFlight := 0
+		for _, state := range []operations.ListPostgresBranchBackupsQueryParamState{
+			operations.ListPostgresBranchBackupsQueryParamStatePending,
+			operations.ListPostgresBranchBackupsQueryParamStateRunning,
+		} {
+			resp, err := client.Backups.ListPostgresBranchBackups(ctx, operations.ListPostgresBranchBackupsRequest{
+				Organization: testAccOrg,
+				Database:     database,
+				Branch:       branch,
+				State:        state.ToPointer(),
+			})
+			if err != nil {
+				return 0, err
+			}
+			if resp.Object != nil {
+				inFlight += len(resp.Object.Data)
+			}
+		}
+		return inFlight, nil
+	})
+}
+
+func waitForNoInFlightVitessBackups(t *testing.T, database, branch string) {
+	t.Helper()
+
+	client := testAccSDKClient()
+	waitForNoInFlightBackups(t, branch, func(ctx context.Context) (int, error) {
+		inFlight := 0
+		for _, state := range []operations.ListVitessBranchBackupsQueryParamState{
+			operations.ListVitessBranchBackupsQueryParamStatePending,
+			operations.ListVitessBranchBackupsQueryParamStateRunning,
+		} {
+			resp, err := client.Backups.ListVitessBranchBackups(ctx, operations.ListVitessBranchBackupsRequest{
+				Organization: testAccOrg,
+				Database:     database,
+				Branch:       branch,
+				State:        state.ToPointer(),
+			})
+			if err != nil {
+				return 0, err
+			}
+			if resp.Object != nil {
+				inFlight += len(resp.Object.Data)
+			}
+		}
+		return inFlight, nil
+	})
+}
+
+func waitForNoInFlightBackups(t *testing.T, branch string, countInFlight func(context.Context) (int, error)) {
+	t.Helper()
+
+	ctx := context.Background()
+	deadline := time.Now().Add(backupWaitTimeout)
+	for {
+		inFlight, err := countInFlight(ctx)
+		if err != nil {
+			t.Fatalf("listing in-flight backups on branch %q: %s", branch, err)
+		}
+		if inFlight == 0 {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("%d backup(s) still in flight on branch %q after waiting %s", inFlight, branch, backupWaitTimeout)
+		}
+		t.Logf("waiting for %d in-flight backup(s) on branch %q to complete", inFlight, branch)
+		time.Sleep(backupWaitInterval)
+	}
 }

--- a/internal/provider/vitessbranchbackup_resource_test.go
+++ b/internal/provider/vitessbranchbackup_resource_test.go
@@ -21,7 +21,10 @@ func TestAccVitessBranchBackupResource_Lifecycle(t *testing.T) {
 	resourceAddress := "planetscale_vitess_branch_backup.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			waitForNoInFlightVitessBackups(t, databaseName, branchName)
+		},
 		ProtoV6ProviderFactories: testAccProviders(),
 		Steps: []resource.TestStep{
 			{


### PR DESCRIPTION
Our backup integration tests reuse existing PlanetScale branches to allow them to complete quickly.

If a previous integration test run was cancelled or is in-progress, these branches could have an existing backup running which will cause these tests to fail with the error:

> Cannot create backup while another manual backup is already running.

These branches are small, so it's expected for these backups to complete quickly. This pre-check ensures the integration test does not fail and require manually re-running the job.