### PR TITLE
Create release for `v1.7.0`

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -5,8 +5,8 @@ management:
   docVersion: v1
   speakeasyVersion: 1.793.0
   generationVersion: 2.928.0
-  releaseVersion: 1.6.0
-  configChecksum: 2903f689f1907338345bcdd07579df08
+  releaseVersion: 1.7.0
+  configChecksum: beb7ff10230ab6a6c04a8bf7541a23d4
 persistentEdits:
   generation_id: 60e31278-cdaa-4542-9c58-f63a48b53d1a
   pristine_commit_hash: 0f48b87acc4799dd3898ffc3569dccdf1e31fb15

--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -32,7 +32,7 @@ generation:
     generateNewTests: true
     skipResponseBodyAssertions: false
 terraform:
-  version: 1.6.0
+  version: 1.7.0
   additionalActions: []
   additionalDataSources: []
   additionalDependencies: []

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ terraform {
   required_providers {
     planetscale = {
       source  = "planetscale/planetscale"
-      version = "1.6.0"
+      version = "1.7.0"
     }
   }
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ terraform {
   required_providers {
     planetscale = {
       source  = "planetscale/planetscale"
-      version = "1.6.0"
+      version = "1.7.0"
     }
   }
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     planetscale = {
       source  = "planetscale/planetscale"
-      version = "1.6.0"
+      version = "1.7.0"
     }
   }
 }

--- a/internal/sdk/planetscale.go
+++ b/internal/sdk/planetscale.go
@@ -157,9 +157,9 @@ func WithTimeout(timeout time.Duration) SDKOption {
 // New creates a new instance of the SDK with the provided options
 func New(opts ...SDKOption) *PlanetScale {
 	sdk := &PlanetScale{
-		SDKVersion: "1.6.0",
+		SDKVersion: "1.7.0",
 		sdkConfiguration: config.SDKConfiguration{
-			UserAgent:  "speakeasy-sdk/terraform 1.6.0 2.928.0 v1 github.com/planetscale/terraform-provider-planetscale/internal/sdk",
+			UserAgent:  "speakeasy-sdk/terraform 1.7.0 2.928.0 v1 github.com/planetscale/terraform-provider-planetscale/internal/sdk",
 			ServerList: ServerList,
 		},
 		hooks: hooks.New(),


### PR DESCRIPTION
`v1.7.0` adds the `planetscale_vitess_keyspace` resource (plus keyspace data sources) for creating, resizing, and importing Vitess keyspaces.

- #323


Made with [Cursor](https://cursor.com)