### PR TITLE
Create release for `v1.7.1`

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -5,8 +5,8 @@ management:
   docVersion: v1
   speakeasyVersion: 1.793.0
   generationVersion: 2.928.0
-  releaseVersion: 1.7.0
-  configChecksum: beb7ff10230ab6a6c04a8bf7541a23d4
+  releaseVersion: 1.7.1
+  configChecksum: ee312a8aca8eb27bc1d68e7e3936ce3f
 persistentEdits:
   generation_id: 60e31278-cdaa-4542-9c58-f63a48b53d1a
   pristine_commit_hash: 0f48b87acc4799dd3898ffc3569dccdf1e31fb15

--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -32,7 +32,7 @@ generation:
     generateNewTests: true
     skipResponseBodyAssertions: false
 terraform:
-  version: 1.7.0
+  version: 1.7.1
   additionalActions: []
   additionalDataSources: []
   additionalDependencies: []

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ terraform {
   required_providers {
     planetscale = {
       source  = "planetscale/planetscale"
-      version = "1.7.0"
+      version = "1.7.1"
     }
   }
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ terraform {
   required_providers {
     planetscale = {
       source  = "planetscale/planetscale"
-      version = "1.7.0"
+      version = "1.7.1"
     }
   }
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     planetscale = {
       source  = "planetscale/planetscale"
-      version = "1.7.0"
+      version = "1.7.1"
     }
   }
 }

--- a/internal/sdk/planetscale.go
+++ b/internal/sdk/planetscale.go
@@ -157,9 +157,9 @@ func WithTimeout(timeout time.Duration) SDKOption {
 // New creates a new instance of the SDK with the provided options
 func New(opts ...SDKOption) *PlanetScale {
 	sdk := &PlanetScale{
-		SDKVersion: "1.7.0",
+		SDKVersion: "1.7.1",
 		sdkConfiguration: config.SDKConfiguration{
-			UserAgent:  "speakeasy-sdk/terraform 1.7.0 2.928.0 v1 github.com/planetscale/terraform-provider-planetscale/internal/sdk",
+			UserAgent:  "speakeasy-sdk/terraform 1.7.1 2.928.0 v1 github.com/planetscale/terraform-provider-planetscale/internal/sdk",
 			ServerList: ServerList,
 		},
 		hooks: hooks.New(),


### PR DESCRIPTION
`v1.7.1` is a re-cut of the `v1.7.0` release. GitHub immutable releases locked the `v1.7.0` tag name after an empty release was published, so GoReleaser could not attach assets or republish under that tag.

Same contents as intended for `v1.7.0`:
- #323 — `planetscale_vitess_keyspace` resource + data sources

After merge, tag the merge commit as `v1.7.1` (do not reuse `v1.7.0`) and push the tag to trigger the release workflow.


Made with [Cursor](https://cursor.com)