### PR TITLE
Add dormant Neki provider overlays

### DIFF
--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -6,16 +6,22 @@ sources:
             - location: schemas/openapi.yaml
         overlays:
             - location: schemas/overlay-terraform.yaml
+            - location: schemas/overlay-terraform-neki-api.yaml
 
             - location: schemas/overlay-terraform-branches.yaml
             - location: schemas/overlay-terraform-postgres-branch.yaml
             - location: schemas/overlay-terraform-vitess-branch.yaml
+            - location: schemas/overlay-terraform-neki-branch.yaml
 
             - location: schemas/overlay-terraform-database_vitess.yaml
             - location: schemas/overlay-terraform-database_postgres.yaml
+            - location: schemas/overlay-terraform-database_neki.yaml
             - location: schemas/overlay-terraform-databases.yaml
             - location: schemas/overlay-terraform-organization.yaml
             - location: schemas/overlay-terraform-organizations.yaml
+            - location: schemas/overlay-terraform-neki-branch-role.yaml
+            - location: schemas/overlay-terraform-neki-redacted-branch-role.yaml
+            - location: schemas/overlay-terraform-neki-branch-roles.yaml
             - location: schemas/overlay-terraform-postgres-branch-role.yaml
             - location: schemas/overlay-terraform-postgres-redacted-branch-role.yaml
             - location: schemas/overlay-terraform-postgres-branch-roles.yaml
@@ -23,18 +29,24 @@ sources:
             - location: schemas/overlay-terraform-vitess-branch-passwords.yaml
             - location: schemas/overlay-terraform-vitess-keyspace.yaml
             - location: schemas/overlay-terraform-vitess-keyspaces.yaml
+            - location: schemas/overlay-terraform-neki-configuration-profile.yaml
+            - location: schemas/overlay-terraform-neki-configuration-profiles.yaml
 
             - location: schemas/overlay-terraform-backup-policies.yaml
             - location: schemas/overlay-terraform-vitess-backup-policy.yaml
             - location: schemas/overlay-terraform-postgres-backup-policy.yaml
+            - location: schemas/overlay-terraform-neki-backup-policy.yaml
             - location: schemas/overlay-terraform-vitess-backup-policies.yaml
             - location: schemas/overlay-terraform-postgres-backup-policies.yaml
+            - location: schemas/overlay-terraform-neki-backup-policies.yaml
 
             - location: schemas/overlay-terraform-backups.yaml
             - location: schemas/overlay-terraform-vitess-branch-backup.yaml
             - location: schemas/overlay-terraform-postgres-branch-backup.yaml
+            - location: schemas/overlay-terraform-neki-branch-backup.yaml
             - location: schemas/overlay-terraform-vitess-branch-backups.yaml
             - location: schemas/overlay-terraform-postgres-branch-backups.yaml
+            - location: schemas/overlay-terraform-neki-branch-backups.yaml
 
             - location: schemas/overlay-terraform-postgres-bouncer.yaml
             - location: schemas/overlay-terraform-postgres-bouncers.yaml

--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -6,22 +6,25 @@ sources:
             - location: schemas/openapi.yaml
         overlays:
             - location: schemas/overlay-terraform.yaml
-            - location: schemas/overlay-terraform-neki-api.yaml
+            # Neki preview overlays are intentionally dormant. Uncomment every
+            # "Neki preview" line, then run `make generate`, to build and test
+            # the unreleased Neki resources locally.
+            # - location: schemas/overlay-terraform-neki-api.yaml # Neki preview
 
             - location: schemas/overlay-terraform-branches.yaml
             - location: schemas/overlay-terraform-postgres-branch.yaml
             - location: schemas/overlay-terraform-vitess-branch.yaml
-            - location: schemas/overlay-terraform-neki-branch.yaml
+            # - location: schemas/overlay-terraform-neki-branch.yaml # Neki preview
 
             - location: schemas/overlay-terraform-database_vitess.yaml
             - location: schemas/overlay-terraform-database_postgres.yaml
-            - location: schemas/overlay-terraform-database_neki.yaml
+            # - location: schemas/overlay-terraform-database_neki.yaml # Neki preview
             - location: schemas/overlay-terraform-databases.yaml
             - location: schemas/overlay-terraform-organization.yaml
             - location: schemas/overlay-terraform-organizations.yaml
-            - location: schemas/overlay-terraform-neki-branch-role.yaml
-            - location: schemas/overlay-terraform-neki-redacted-branch-role.yaml
-            - location: schemas/overlay-terraform-neki-branch-roles.yaml
+            # - location: schemas/overlay-terraform-neki-branch-role.yaml # Neki preview
+            # - location: schemas/overlay-terraform-neki-redacted-branch-role.yaml # Neki preview
+            # - location: schemas/overlay-terraform-neki-branch-roles.yaml # Neki preview
             - location: schemas/overlay-terraform-postgres-branch-role.yaml
             - location: schemas/overlay-terraform-postgres-redacted-branch-role.yaml
             - location: schemas/overlay-terraform-postgres-branch-roles.yaml
@@ -29,24 +32,24 @@ sources:
             - location: schemas/overlay-terraform-vitess-branch-passwords.yaml
             - location: schemas/overlay-terraform-vitess-keyspace.yaml
             - location: schemas/overlay-terraform-vitess-keyspaces.yaml
-            - location: schemas/overlay-terraform-neki-configuration-profile.yaml
-            - location: schemas/overlay-terraform-neki-configuration-profiles.yaml
+            # - location: schemas/overlay-terraform-neki-configuration-profile.yaml # Neki preview
+            # - location: schemas/overlay-terraform-neki-configuration-profiles.yaml # Neki preview
 
             - location: schemas/overlay-terraform-backup-policies.yaml
             - location: schemas/overlay-terraform-vitess-backup-policy.yaml
             - location: schemas/overlay-terraform-postgres-backup-policy.yaml
-            - location: schemas/overlay-terraform-neki-backup-policy.yaml
+            # - location: schemas/overlay-terraform-neki-backup-policy.yaml # Neki preview
             - location: schemas/overlay-terraform-vitess-backup-policies.yaml
             - location: schemas/overlay-terraform-postgres-backup-policies.yaml
-            - location: schemas/overlay-terraform-neki-backup-policies.yaml
+            # - location: schemas/overlay-terraform-neki-backup-policies.yaml # Neki preview
 
             - location: schemas/overlay-terraform-backups.yaml
             - location: schemas/overlay-terraform-vitess-branch-backup.yaml
             - location: schemas/overlay-terraform-postgres-branch-backup.yaml
-            - location: schemas/overlay-terraform-neki-branch-backup.yaml
+            # - location: schemas/overlay-terraform-neki-branch-backup.yaml # Neki preview
             - location: schemas/overlay-terraform-vitess-branch-backups.yaml
             - location: schemas/overlay-terraform-postgres-branch-backups.yaml
-            - location: schemas/overlay-terraform-neki-branch-backups.yaml
+            # - location: schemas/overlay-terraform-neki-branch-backups.yaml # Neki preview
 
             - location: schemas/overlay-terraform-postgres-bouncer.yaml
             - location: schemas/overlay-terraform-postgres-bouncers.yaml

--- a/internal/provider/nekibackuppolicy_resource_test.go
+++ b/internal/provider/nekibackuppolicy_resource_test.go
@@ -1,0 +1,62 @@
+package provider
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+func TestAccNekiBackupPolicyResource_Lifecycle(t *testing.T) {
+	t.Parallel()
+
+	databaseName := randomWithPrefix("testacc-neki-policy")
+	policyName := randomWithPrefix("test-backup-policy")
+	resourceAddress := "planetscale_neki_backup_policy.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccNekiPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders(),
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.TestNameDirectory(),
+				ConfigVariables: config.Variables{
+					"organization":  config.StringVariable(testAccOrg),
+					"database_name": config.StringVariable(databaseName),
+					"policy_name":   config.StringVariable(policyName),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceAddress, tfjsonpath.New("id"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceAddress, tfjsonpath.New("name"), knownvalue.StringExact(policyName)),
+					statecheck.ExpectKnownValue(resourceAddress, tfjsonpath.New("target"), knownvalue.StringExact("development")),
+					statecheck.ExpectKnownValue(resourceAddress, tfjsonpath.New("retention_value"), knownvalue.Int64Exact(7)),
+				},
+			},
+			{
+				ConfigDirectory: config.TestNameDirectory(),
+				ConfigVariables: config.Variables{
+					"organization":  config.StringVariable(testAccOrg),
+					"database_name": config.StringVariable(databaseName),
+					"policy_name":   config.StringVariable(policyName),
+				},
+				ResourceName: resourceAddress,
+				ImportState:  true,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					rs := s.RootModule().Resources[resourceAddress]
+					jsonBytes, err := json.Marshal(map[string]string{
+						"database":     rs.Primary.Attributes["database"],
+						"id":           rs.Primary.Attributes["id"],
+						"organization": rs.Primary.Attributes["organization"],
+					})
+					return string(jsonBytes), err
+				},
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/internal/provider/nekibranch_resource_test.go
+++ b/internal/provider/nekibranch_resource_test.go
@@ -1,0 +1,77 @@
+package provider
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+func TestAccNekiBranchResource_Lifecycle(t *testing.T) {
+	t.Parallel()
+
+	databaseName := randomWithPrefix("testacc-neki")
+	branchNameOriginal := "main"
+	branchNameRenamed := randomWithPrefix("main-renamed")
+	resourceAddress := "planetscale_neki_branch.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccNekiPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders(),
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.TestNameDirectory(),
+				ConfigVariables: config.Variables{
+					"organization":  config.StringVariable(testAccOrg),
+					"database_name": config.StringVariable(databaseName),
+					"branch_name":   config.StringVariable(branchNameOriginal),
+					"cluster_size":  config.StringVariable("PS_DEV_AWS_ARM"),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceAddress, tfjsonpath.New("id"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceAddress, tfjsonpath.New("name"), knownvalue.StringExact(branchNameOriginal)),
+					statecheck.ExpectKnownValue(resourceAddress, tfjsonpath.New("state"), knownvalue.StringExact("ready")),
+				},
+			},
+			{
+				ConfigDirectory: config.TestNameDirectory(),
+				ConfigVariables: config.Variables{
+					"organization":  config.StringVariable(testAccOrg),
+					"database_name": config.StringVariable(databaseName),
+					"branch_name":   config.StringVariable(branchNameRenamed),
+					"cluster_size":  config.StringVariable("PS_DEV_AWS_ARM"),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceAddress, tfjsonpath.New("name"), knownvalue.StringExact(branchNameRenamed)),
+				},
+			},
+			{
+				ConfigDirectory: config.TestNameDirectory(),
+				ConfigVariables: config.Variables{
+					"organization":  config.StringVariable(testAccOrg),
+					"database_name": config.StringVariable(databaseName),
+					"branch_name":   config.StringVariable(branchNameRenamed),
+					"cluster_size":  config.StringVariable("PS_DEV_AWS_ARM"),
+				},
+				ResourceName: resourceAddress,
+				ImportState:  true,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					rs := s.RootModule().Resources[resourceAddress]
+					jsonBytes, err := json.Marshal(map[string]string{
+						"database":     rs.Primary.Attributes["database"],
+						"id":           rs.Primary.Attributes["id"],
+						"organization": rs.Primary.Attributes["organization"],
+					})
+					return string(jsonBytes), err
+				},
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"cluster_size"},
+			},
+		},
+	})
+}

--- a/internal/provider/nekibranchbackup_resource_test.go
+++ b/internal/provider/nekibranchbackup_resource_test.go
@@ -1,0 +1,63 @@
+package provider
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+func TestAccNekiBranchBackupResource_Lifecycle(t *testing.T) {
+	t.Parallel()
+
+	databaseName := randomWithPrefix("testacc-neki-backup")
+	backupName := randomWithPrefix("test-backup")
+	resourceAddress := "planetscale_neki_branch_backup.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccNekiPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders(),
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.TestNameDirectory(),
+				ConfigVariables: config.Variables{
+					"organization":  config.StringVariable(testAccOrg),
+					"database_name": config.StringVariable(databaseName),
+					"backup_name":   config.StringVariable(backupName),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceAddress, tfjsonpath.New("id"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceAddress, tfjsonpath.New("name"), knownvalue.StringExact(backupName)),
+					statecheck.ExpectKnownValue(resourceAddress, tfjsonpath.New("state"), knownvalue.StringExact("success")),
+				},
+			},
+			{
+				ConfigDirectory: config.TestNameDirectory(),
+				ConfigVariables: config.Variables{
+					"organization":  config.StringVariable(testAccOrg),
+					"database_name": config.StringVariable(databaseName),
+					"backup_name":   config.StringVariable(backupName),
+				},
+				ResourceName: resourceAddress,
+				ImportState:  true,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					rs := s.RootModule().Resources[resourceAddress]
+					jsonBytes, err := json.Marshal(map[string]string{
+						"branch":       rs.Primary.Attributes["branch"],
+						"database":     rs.Primary.Attributes["database"],
+						"id":           rs.Primary.Attributes["id"],
+						"organization": rs.Primary.Attributes["organization"],
+					})
+					return string(jsonBytes), err
+				},
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"retention_value", "retention_unit"},
+			},
+		},
+	})
+}

--- a/internal/provider/nekibranchrole_resource_test.go
+++ b/internal/provider/nekibranchrole_resource_test.go
@@ -1,0 +1,76 @@
+package provider
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+func TestAccNekiBranchRoleResource_Lifecycle(t *testing.T) {
+	t.Parallel()
+
+	databaseName := randomWithPrefix("testacc-neki-role")
+	roleNameOriginal := randomWithPrefix("test-role")
+	roleNameRenamed := randomWithPrefix("test-role-renamed")
+	resourceAddress := "planetscale_neki_branch_role.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccNekiPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders(),
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.TestNameDirectory(),
+				ConfigVariables: config.Variables{
+					"organization":  config.StringVariable(testAccOrg),
+					"database_name": config.StringVariable(databaseName),
+					"role_name":     config.StringVariable(roleNameOriginal),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceAddress, tfjsonpath.New("id"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceAddress, tfjsonpath.New("name"), knownvalue.StringExact(roleNameOriginal)),
+					statecheck.ExpectKnownValue(resourceAddress, tfjsonpath.New("username"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceAddress, tfjsonpath.New("password"), knownvalue.NotNull()),
+				},
+			},
+			{
+				ConfigDirectory: config.TestNameDirectory(),
+				ConfigVariables: config.Variables{
+					"organization":  config.StringVariable(testAccOrg),
+					"database_name": config.StringVariable(databaseName),
+					"role_name":     config.StringVariable(roleNameRenamed),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceAddress, tfjsonpath.New("name"), knownvalue.StringExact(roleNameRenamed)),
+				},
+			},
+			{
+				ConfigDirectory: config.TestNameDirectory(),
+				ConfigVariables: config.Variables{
+					"organization":  config.StringVariable(testAccOrg),
+					"database_name": config.StringVariable(databaseName),
+					"role_name":     config.StringVariable(roleNameRenamed),
+				},
+				ResourceName: resourceAddress,
+				ImportState:  true,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					rs := s.RootModule().Resources[resourceAddress]
+					jsonBytes, err := json.Marshal(map[string]string{
+						"branch":       rs.Primary.Attributes["branch"],
+						"database":     rs.Primary.Attributes["database"],
+						"id":           rs.Primary.Attributes["id"],
+						"organization": rs.Primary.Attributes["organization"],
+					})
+					return string(jsonBytes), err
+				},
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"password"},
+			},
+		},
+	})
+}

--- a/internal/provider/nekiconfigurationprofile_resource_test.go
+++ b/internal/provider/nekiconfigurationprofile_resource_test.go
@@ -1,0 +1,77 @@
+package provider
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+func TestAccNekiConfigurationProfileResource_Lifecycle(t *testing.T) {
+	t.Parallel()
+
+	databaseName := randomWithPrefix("testacc-neki-profile")
+	profileNameOriginal := randomWithPrefix("test-profile")
+	profileNameRenamed := randomWithPrefix("test-profile-renamed")
+	resourceAddress := "planetscale_neki_configuration_profile.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccNekiPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders(),
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.TestNameDirectory(),
+				ConfigVariables: config.Variables{
+					"organization":  config.StringVariable(testAccOrg),
+					"database_name": config.StringVariable(databaseName),
+					"profile_name":  config.StringVariable(profileNameOriginal),
+					"cluster_size":  config.StringVariable("PS_DEV_AWS_ARM"),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceAddress, tfjsonpath.New("name"), knownvalue.StringExact(profileNameOriginal)),
+					statecheck.ExpectKnownValue(resourceAddress, tfjsonpath.New("cluster_size"), knownvalue.StringExact("PS_DEV_AWS_ARM")),
+					statecheck.ExpectKnownValue(resourceAddress, tfjsonpath.New("state"), knownvalue.StringExact("ready")),
+				},
+			},
+			{
+				ConfigDirectory: config.TestNameDirectory(),
+				ConfigVariables: config.Variables{
+					"organization":  config.StringVariable(testAccOrg),
+					"database_name": config.StringVariable(databaseName),
+					"profile_name":  config.StringVariable(profileNameRenamed),
+					"cluster_size":  config.StringVariable("PS_DEV_AWS_ARM"),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceAddress, tfjsonpath.New("name"), knownvalue.StringExact(profileNameRenamed)),
+				},
+			},
+			{
+				ConfigDirectory: config.TestNameDirectory(),
+				ConfigVariables: config.Variables{
+					"organization":  config.StringVariable(testAccOrg),
+					"database_name": config.StringVariable(databaseName),
+					"profile_name":  config.StringVariable(profileNameRenamed),
+					"cluster_size":  config.StringVariable("PS_DEV_AWS_ARM"),
+				},
+				ResourceName: resourceAddress,
+				ImportState:  true,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					rs := s.RootModule().Resources[resourceAddress]
+					jsonBytes, err := json.Marshal(map[string]string{
+						"branch":       rs.Primary.Attributes["branch"],
+						"database":     rs.Primary.Attributes["database"],
+						"name":         rs.Primary.Attributes["name"],
+						"organization": rs.Primary.Attributes["organization"],
+					})
+					return string(jsonBytes), err
+				},
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -42,6 +42,14 @@ func testAccPreCheck(t *testing.T) {
 	t.Fatal("Both PLANETSCALE_SERVICE_TOKEN and PLANETSCALE_SERVICE_TOKEN_ID must be set for acceptance tests")
 }
 
+func testAccNekiPreCheck(t *testing.T) {
+	t.Helper()
+	testAccPreCheck(t)
+	if os.Getenv("PLANETSCALE_NEKI_ENABLED") != "true" {
+		t.Skip("skipping Neki acceptance test; set PLANETSCALE_NEKI_ENABLED=true")
+	}
+}
+
 // randomWithPrefix generates a random string with the given prefix.
 func randomWithPrefix(prefix string) string {
 	return fmt.Sprintf("%s-%d", prefix, rand.Intn(1000000))

--- a/internal/provider/testdata/TestAccNekiBackupPolicyResource_Lifecycle/main.tf
+++ b/internal/provider/testdata/TestAccNekiBackupPolicyResource_Lifecycle/main.tf
@@ -1,0 +1,30 @@
+variable "organization" {
+  type = string
+}
+
+variable "database_name" {
+  type = string
+}
+
+variable "policy_name" {
+  type = string
+}
+
+resource "planetscale_neki_branch" "main" {
+  organization = var.organization
+  database     = var.database_name
+  name         = "main"
+  cluster_size = "PS_DEV_AWS_ARM"
+}
+
+resource "planetscale_neki_backup_policy" "test" {
+  organization    = var.organization
+  database        = planetscale_neki_branch.main.database
+  name            = var.policy_name
+  target          = "development"
+  retention_value = 7
+  retention_unit  = "day"
+  frequency_value = 1
+  frequency_unit  = "day"
+  schedule_time   = "04:00"
+}

--- a/internal/provider/testdata/TestAccNekiBranchBackupResource_Lifecycle/main.tf
+++ b/internal/provider/testdata/TestAccNekiBranchBackupResource_Lifecycle/main.tf
@@ -1,0 +1,27 @@
+variable "organization" {
+  type = string
+}
+
+variable "database_name" {
+  type = string
+}
+
+variable "backup_name" {
+  type = string
+}
+
+resource "planetscale_neki_branch" "main" {
+  organization = var.organization
+  database     = var.database_name
+  name         = "main"
+  cluster_size = "PS_DEV_AWS_ARM"
+}
+
+resource "planetscale_neki_branch_backup" "test" {
+  organization    = var.organization
+  database        = planetscale_neki_branch.main.database
+  branch          = planetscale_neki_branch.main.name
+  name            = var.backup_name
+  retention_value = 1
+  retention_unit  = "day"
+}

--- a/internal/provider/testdata/TestAccNekiBranchResource_Lifecycle/main.tf
+++ b/internal/provider/testdata/TestAccNekiBranchResource_Lifecycle/main.tf
@@ -1,0 +1,22 @@
+variable "organization" {
+  type = string
+}
+
+variable "database_name" {
+  type = string
+}
+
+variable "branch_name" {
+  type = string
+}
+
+variable "cluster_size" {
+  type = string
+}
+
+resource "planetscale_neki_branch" "test" {
+  organization = var.organization
+  database     = var.database_name
+  name         = var.branch_name
+  cluster_size = var.cluster_size
+}

--- a/internal/provider/testdata/TestAccNekiBranchRoleResource_Lifecycle/main.tf
+++ b/internal/provider/testdata/TestAccNekiBranchRoleResource_Lifecycle/main.tf
@@ -1,0 +1,25 @@
+variable "organization" {
+  type = string
+}
+
+variable "database_name" {
+  type = string
+}
+
+variable "role_name" {
+  type = string
+}
+
+resource "planetscale_neki_branch" "main" {
+  organization = var.organization
+  database     = var.database_name
+  name         = "main"
+  cluster_size = "PS_DEV_AWS_ARM"
+}
+
+resource "planetscale_neki_branch_role" "test" {
+  organization = var.organization
+  database     = planetscale_neki_branch.main.database
+  branch       = planetscale_neki_branch.main.name
+  name         = var.role_name
+}

--- a/internal/provider/testdata/TestAccNekiConfigurationProfileResource_Lifecycle/main.tf
+++ b/internal/provider/testdata/TestAccNekiConfigurationProfileResource_Lifecycle/main.tf
@@ -1,0 +1,30 @@
+variable "organization" {
+  type = string
+}
+
+variable "database_name" {
+  type = string
+}
+
+variable "profile_name" {
+  type = string
+}
+
+variable "cluster_size" {
+  type = string
+}
+
+resource "planetscale_neki_branch" "main" {
+  organization = var.organization
+  database     = var.database_name
+  name         = "main"
+  cluster_size = var.cluster_size
+}
+
+resource "planetscale_neki_configuration_profile" "test" {
+  organization = var.organization
+  database     = planetscale_neki_branch.main.database
+  branch       = planetscale_neki_branch.main.name
+  name         = var.profile_name
+  cluster_size = var.cluster_size
+}

--- a/schemas/overlay-terraform-backup-policies.yaml
+++ b/schemas/overlay-terraform-backup-policies.yaml
@@ -98,6 +98,23 @@ actions:
     description: Copy backup policy item path as base for postgres
     copy: $.paths['/organizations/{organization}/databases/{database}/backup-policies/{id}']
 
+  - target: $.paths
+    description: Add Neki backup policy path entries
+    update:
+      /organizations/{organization}/databases/{database}/backup-policies#neki: {}
+
+  - target: $.paths['/organizations/{organization}/databases/{database}/backup-policies#neki']
+    description: Copy backup policies collection path as base for Neki
+    copy: $.paths['/organizations/{organization}/databases/{database}/backup-policies']
+
+  - target: $.paths
+    update:
+      /organizations/{organization}/databases/{database}/backup-policies/{id}#neki: {}
+
+  - target: $.paths['/organizations/{organization}/databases/{database}/backup-policies/{id}#neki']
+    description: Copy backup policy item path as base for Neki
+    copy: $.paths['/organizations/{organization}/databases/{database}/backup-policies/{id}']
+
   # Remove copied base backup policy paths
   - target: $.paths['/organizations/{organization}/databases/{database}/backup-policies']
     remove: true

--- a/schemas/overlay-terraform-backups.yaml
+++ b/schemas/overlay-terraform-backups.yaml
@@ -136,6 +136,23 @@ actions:
     description: Copy backup item path as base for postgres
     copy: $.paths['/organizations/{organization}/databases/{database}/branches/{branch}/backups/{id}']
 
+  - target: $.paths
+    description: Add Neki backup path entries
+    update:
+      /organizations/{organization}/databases/{database}/branches/{branch}/backups#neki: {}
+
+  - target: $.paths['/organizations/{organization}/databases/{database}/branches/{branch}/backups#neki']
+    description: Copy backups collection path as base for Neki
+    copy: $.paths['/organizations/{organization}/databases/{database}/branches/{branch}/backups']
+
+  - target: $.paths
+    update:
+      /organizations/{organization}/databases/{database}/branches/{branch}/backups/{id}#neki: {}
+
+  - target: $.paths['/organizations/{organization}/databases/{database}/branches/{branch}/backups/{id}#neki']
+    description: Copy backup item path as base for Neki
+    copy: $.paths['/organizations/{organization}/databases/{database}/branches/{branch}/backups/{id}']
+
   # Remove copied base backup paths
   - target: $.paths['/organizations/{organization}/databases/{database}/branches/{branch}/backups']
     remove: true

--- a/schemas/overlay-terraform-branches.yaml
+++ b/schemas/overlay-terraform-branches.yaml
@@ -288,6 +288,26 @@ actions:
   - target: $.paths['/organizations/{organization}/databases/{database}/branches#vitess'].get
     remove: true
 
+  - target: $.paths
+    description: Add NekiBranch path entries
+    update:
+      /organizations/{organization}/databases/{database}/branches#neki: {}
+
+  - target: $.paths['/organizations/{organization}/databases/{database}/branches#neki']
+    description: Copy branches path as base for Neki
+    copy: $.paths['/organizations/{organization}/databases/{database}/branches']
+
+  - target: $.paths
+    update:
+      /organizations/{organization}/databases/{database}/branches/{branch}#neki: {}
+
+  - target: $.paths['/organizations/{organization}/databases/{database}/branches/{branch}#neki']
+    description: Copy branch path as base for Neki
+    copy: $.paths['/organizations/{organization}/databases/{database}/branches/{branch}']
+
+  - target: $.paths['/organizations/{organization}/databases/{database}/branches#neki'].get
+    remove: true
+
   # Remove copied base branches paths
   - target: $.paths['/organizations/{organization}/databases/{database}/branches']
     remove: true

--- a/schemas/overlay-terraform-database_neki.yaml
+++ b/schemas/overlay-terraform-database_neki.yaml
@@ -1,0 +1,55 @@
+overlay: 1.1.0
+x-speakeasy-jsonpath: rfc9535
+info:
+  title: Terraform generation overlay for planetscale_database_neki data source
+  version: 0.0.1
+actions:
+  - target: $.paths
+    update:
+      /organizations/{organization}/databases#neki: {}
+
+  - target: $.paths['/organizations/{organization}/databases#neki']
+    copy: $.paths['/organizations/{organization}/databases']
+
+  - target: $.paths
+    update:
+      /organizations/{organization}/databases/{database}#neki: {}
+
+  - target: $.paths['/organizations/{organization}/databases/{database}#neki']
+    copy: $.paths['/organizations/{organization}/databases/{database}']
+
+  - target: $.paths['/organizations/{organization}/databases#neki'].get
+    remove: true
+
+  - target: $.paths['/organizations/{organization}/databases#neki'].post.requestBody.content['application/json'].schema.properties.kind
+    update:
+      type: string
+      const: neki
+      default: neki
+      description: The kind of database. Always neki.
+
+  - target: $.paths['/organizations/{organization}/databases/{database}#neki'].get
+    update:
+      operationId: get_neki_database
+      summary: Get a Neki database
+      x-speakeasy-entity-operation: NekiDatabase#read
+      x-speakeasy-entity-description: Returns information about a PlanetScale Neki database.
+
+  - target: $.paths['/organizations/{organization}/databases/{database}#neki'].get.parameters[?@.name == 'database']
+    update:
+      x-speakeasy-match: id
+
+  - target: $.paths['/organizations/{organization}/databases/{database}#neki'].get.responses['200'].content['application/json'].schema.properties.kind
+    update:
+      const: neki
+      description: The kind of database.
+
+  - target: $.paths['/organizations/{organization}/databases/{database}#neki'].get.responses['200'].content['application/json'].schema.properties.kind.enum
+    remove: true
+
+  - target: $.paths['/organizations/{organization}/databases/{database}#neki'].get.responses['200'].content['application/json'].schema.properties.region
+    update:
+      x-speakeasy-name-override: region_data
+
+  - target: $.paths['/organizations/{organization}/databases/{database}#neki'].get.responses['200'].content['application/json'].schema.properties['allow_data_branching','foreign_keys_enabled','automatic_migrations','migration_table_name','migration_framework','config_change_queued','config_changing']
+    remove: true

--- a/schemas/overlay-terraform-neki-api.yaml
+++ b/schemas/overlay-terraform-neki-api.yaml
@@ -1,0 +1,279 @@
+overlay: 1.1.0
+x-speakeasy-jsonpath: rfc9535
+info:
+  title: Temporary OpenAPI definitions for the Neki Terraform provider
+  version: 0.0.1
+actions:
+  # Source: api-bb Api::V1::NekiShardConfigurationProfilesController and
+  # NekiShardConfigurationProfileSerializer. Remove this overlay once these
+  # public_neki_api operations are included in the published OpenAPI document.
+  - target: $.components.schemas
+    update:
+      NekiConfigurationProfile:
+        type: object
+        additionalProperties: false
+        required:
+          - name
+          - cluster_size
+          - default
+          - replicas
+          - state
+        properties:
+          type:
+            type: string
+            const: NekiConfigurationProfile
+          name:
+            type: string
+            description: The name of the shard configuration profile.
+          architecture:
+            type: string
+            description: The architecture of the profile's cluster size.
+          cluster_size:
+            type: string
+            description: The cluster size used by shards assigned to this profile.
+          cluster_display_name:
+            type: string
+            description: The display name of the cluster size.
+          default:
+            type: boolean
+            description: Whether this is the branch's default configuration profile.
+          metal:
+            type: boolean
+            description: Whether shards using this profile run on metal instances.
+          replicas:
+            type: integer
+            description: The number of replicas for shards using this profile.
+          postgres_major_version:
+            type: integer
+            description: The PostgreSQL major version used by this profile.
+          postgres_minor_version:
+            type: integer
+            description: The PostgreSQL minor version used by this profile.
+          shards:
+            type: integer
+            description: The number of shards assigned to this profile.
+          state:
+            type: string
+            enum:
+              - ready
+              - draft
+              - pending
+              - applying
+            description: The rollout state of the profile.
+          created_at:
+            type: string
+            format: date-time
+          updated_at:
+            type: string
+            format: date-time
+
+  - target: $.paths
+    update:
+      /organizations/{organization}/databases/{database}/branches/{branch}/configuration-profiles:
+        get:
+          operationId: list_shard_configuration_profiles
+          summary: List Neki shard configuration profiles
+          tags:
+            - Neki configuration profiles
+          parameters:
+            - name: organization
+              in: path
+              required: true
+              schema:
+                type: string
+            - name: database
+              in: path
+              required: true
+              schema:
+                type: string
+            - name: branch
+              in: path
+              required: true
+              schema:
+                type: string
+          responses:
+            "200":
+              description: Returns shard configuration profiles for the branch.
+              content:
+                application/json:
+                  schema:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/NekiConfigurationProfile"
+        post:
+          operationId: create_shard_configuration_profile
+          summary: Create a Neki shard configuration profile
+          tags:
+            - Neki configuration profiles
+          parameters:
+            - name: organization
+              in: path
+              required: true
+              schema:
+                type: string
+            - name: database
+              in: path
+              required: true
+              schema:
+                type: string
+            - name: branch
+              in: path
+              required: true
+              schema:
+                type: string
+          requestBody:
+            required: true
+            content:
+              application/json:
+                schema:
+                  type: object
+                  additionalProperties: false
+                  required:
+                    - name
+                  properties:
+                    name:
+                      type: string
+                      description: The name of the shard configuration profile.
+                    cluster_size:
+                      type: string
+                      description: The cluster size used by shards assigned to this profile.
+                    replicas:
+                      type: integer
+                      description: The number of replicas for shards using this profile.
+                    postgres_major_version:
+                      type: integer
+                      description: The PostgreSQL major version used by this profile.
+                    postgres_minor_version:
+                      type: integer
+                      description: The PostgreSQL minor version used by this profile.
+          responses:
+            "201":
+              description: Returns the created shard configuration profile.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/NekiConfigurationProfile"
+            "422":
+              description: The profile could not be created.
+
+      /organizations/{organization}/databases/{database}/branches/{branch}/configuration-profiles/{configuration_profile}:
+        get:
+          operationId: get_shard_configuration_profile
+          summary: Get a Neki shard configuration profile
+          tags:
+            - Neki configuration profiles
+          parameters:
+            - name: organization
+              in: path
+              required: true
+              schema:
+                type: string
+            - name: database
+              in: path
+              required: true
+              schema:
+                type: string
+            - name: branch
+              in: path
+              required: true
+              schema:
+                type: string
+            - name: configuration_profile
+              in: path
+              required: true
+              schema:
+                type: string
+          responses:
+            "200":
+              description: Returns the shard configuration profile.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/NekiConfigurationProfile"
+            "404":
+              description: The profile was not found.
+        patch:
+          operationId: update_shard_configuration_profile
+          summary: Update a Neki shard configuration profile
+          tags:
+            - Neki configuration profiles
+          parameters:
+            - name: organization
+              in: path
+              required: true
+              schema:
+                type: string
+            - name: database
+              in: path
+              required: true
+              schema:
+                type: string
+            - name: branch
+              in: path
+              required: true
+              schema:
+                type: string
+            - name: configuration_profile
+              in: path
+              required: true
+              schema:
+                type: string
+          requestBody:
+            required: true
+            content:
+              application/json:
+                schema:
+                  type: object
+                  additionalProperties: false
+                  properties:
+                    name:
+                      type: string
+                      description: The new name of the shard configuration profile.
+                    cluster_size:
+                      type: string
+                      description: The new cluster size for the profile.
+                    replicas:
+                      type: integer
+                      description: The new number of replicas for the profile.
+          responses:
+            "200":
+              description: Returns the updated shard configuration profile.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/NekiConfigurationProfile"
+            "404":
+              description: The profile was not found.
+            "422":
+              description: The profile could not be updated.
+        delete:
+          operationId: delete_shard_configuration_profile
+          summary: Delete a Neki shard configuration profile
+          tags:
+            - Neki configuration profiles
+          parameters:
+            - name: organization
+              in: path
+              required: true
+              schema:
+                type: string
+            - name: database
+              in: path
+              required: true
+              schema:
+                type: string
+            - name: branch
+              in: path
+              required: true
+              schema:
+                type: string
+            - name: configuration_profile
+              in: path
+              required: true
+              schema:
+                type: string
+          responses:
+            "204":
+              description: The profile was deleted.
+            "404":
+              description: The profile was not found.

--- a/schemas/overlay-terraform-neki-backup-policies.yaml
+++ b/schemas/overlay-terraform-neki-backup-policies.yaml
@@ -1,0 +1,20 @@
+overlay: 1.1.0
+x-speakeasy-jsonpath: rfc9535
+info:
+  title: Terraform generation overlay for planetscale_neki_backup_policies data source
+  version: 0.0.1
+actions:
+  - target: $.paths['/organizations/{organization}/databases/{database}/backup-policies#neki'].get
+    update:
+      operationId: list_neki_backup_policies
+      summary: List Neki backup policies
+      x-speakeasy-entity-operation: NekiBackupPolicies#read
+      x-speakeasy-entity-description: Returns PlanetScale Neki database backup policies.
+      x-speakeasy-pagination:
+        type: offsetLimit
+        inputs:
+          - name: page
+            in: parameters
+            type: page
+        outputs:
+          results: $.data

--- a/schemas/overlay-terraform-neki-backup-policy.yaml
+++ b/schemas/overlay-terraform-neki-backup-policy.yaml
@@ -1,0 +1,30 @@
+overlay: 1.1.0
+x-speakeasy-jsonpath: rfc9535
+info:
+  title: Terraform generation overlay for planetscale_neki_backup_policy managed resource
+  version: 0.0.1
+actions:
+  - target: $.paths['/organizations/{organization}/databases/{database}/backup-policies#neki'].post
+    update:
+      operationId: create_neki_backup_policy
+      summary: Create a Neki backup policy
+      x-speakeasy-entity-operation: NekiBackupPolicy#create
+      x-speakeasy-entity-description: Manage a PlanetScale Neki database backup policy.
+
+  - target: $.paths['/organizations/{organization}/databases/{database}/backup-policies/{id}#neki'].get
+    update:
+      operationId: get_neki_backup_policy
+      summary: Get a Neki backup policy
+      x-speakeasy-entity-operation: NekiBackupPolicy#read
+
+  - target: $.paths['/organizations/{organization}/databases/{database}/backup-policies/{id}#neki'].patch
+    update:
+      operationId: update_neki_backup_policy
+      summary: Update a Neki backup policy
+      x-speakeasy-entity-operation: NekiBackupPolicy#update
+
+  - target: $.paths['/organizations/{organization}/databases/{database}/backup-policies/{id}#neki'].delete
+    update:
+      operationId: delete_neki_backup_policy
+      summary: Delete a Neki backup policy
+      x-speakeasy-entity-operation: NekiBackupPolicy#delete

--- a/schemas/overlay-terraform-neki-branch-backup.yaml
+++ b/schemas/overlay-terraform-neki-branch-backup.yaml
@@ -1,0 +1,40 @@
+overlay: 1.1.0
+x-speakeasy-jsonpath: rfc9535
+info:
+  title: Terraform generation overlay for planetscale_neki_branch_backup managed resource
+  version: 0.0.1
+actions:
+  - target: $.paths['/organizations/{organization}/databases/{database}/branches/{branch}/backups#neki'].post
+    update:
+      operationId: create_neki_branch_backup
+      summary: Create a Neki branch backup
+      x-speakeasy-entity-operation: NekiBranchBackup#create
+      x-speakeasy-entity-description: Manage a PlanetScale Neki database branch backup.
+
+  - target: $.paths['/organizations/{organization}/databases/{database}/branches/{branch}/backups/{id}#neki'].get
+    update:
+      operationId: get_neki_branch_backup
+      summary: Get a Neki branch backup
+      x-speakeasy-entity-operation:
+        - NekiBranchBackup#read
+        - entityOperation: NekiBranchBackup#create#2
+          options:
+            polling:
+              name: WaitForComplete
+      x-speakeasy-polling:
+        - name: WaitForComplete
+          delaySeconds: 30
+          intervalSeconds: 30
+          limitCount: 1440
+          failureCriteria:
+            - condition: $statusCode == 200
+            - condition: $response.body#/state == "failed"
+          successCriteria:
+            - condition: $statusCode == 200
+            - condition: $response.body#/state == "success"
+
+  - target: $.paths['/organizations/{organization}/databases/{database}/branches/{branch}/backups/{id}#neki'].delete
+    update:
+      operationId: delete_neki_branch_backup
+      summary: Delete a Neki branch backup
+      x-speakeasy-entity-operation: NekiBranchBackup#delete

--- a/schemas/overlay-terraform-neki-branch-backups.yaml
+++ b/schemas/overlay-terraform-neki-branch-backups.yaml
@@ -1,0 +1,20 @@
+overlay: 1.1.0
+x-speakeasy-jsonpath: rfc9535
+info:
+  title: Terraform generation overlay for planetscale_neki_branch_backups data source
+  version: 0.0.1
+actions:
+  - target: $.paths['/organizations/{organization}/databases/{database}/branches/{branch}/backups#neki'].get
+    update:
+      operationId: list_neki_branch_backups
+      summary: List Neki branch backups
+      x-speakeasy-entity-operation: NekiBranchBackups#read
+      x-speakeasy-entity-description: Returns PlanetScale Neki database branch backups.
+      x-speakeasy-pagination:
+        type: offsetLimit
+        inputs:
+          - name: page
+            in: parameters
+            type: page
+        outputs:
+          results: $.data

--- a/schemas/overlay-terraform-neki-branch-role.yaml
+++ b/schemas/overlay-terraform-neki-branch-role.yaml
@@ -1,0 +1,99 @@
+overlay: 1.1.0
+x-speakeasy-jsonpath: rfc9535
+info:
+  title: Terraform generation overlay for planetscale_neki_branch_role managed and data resources
+  version: 0.0.1
+actions:
+  - target: $.paths
+    update:
+      /organizations/{organization}/databases/{database}/branches/{branch}/roles#neki: {}
+
+  - target: $.paths['/organizations/{organization}/databases/{database}/branches/{branch}/roles#neki']
+    copy: $.paths['/organizations/{organization}/databases/{database}/branches/{branch}/roles']
+
+  - target: $.paths
+    update:
+      /organizations/{organization}/databases/{database}/branches/{branch}/roles/{id}#neki: {}
+
+  - target: $.paths['/organizations/{organization}/databases/{database}/branches/{branch}/roles/{id}#neki']
+    copy: $.paths['/organizations/{organization}/databases/{database}/branches/{branch}/roles/{id}']
+
+  - target: $.paths['/organizations/{organization}/databases/{database}/branches/{branch}/roles#neki'].post
+    update:
+      operationId: create_neki_role
+      summary: Create a Neki role
+      x-speakeasy-entity-operation: NekiBranchRole#create
+      x-speakeasy-entity-description: Manage a PlanetScale Neki branch role.
+
+  - target: $.paths['/organizations/{organization}/databases/{database}/branches/{branch}/roles/{id}#neki'].get
+    update:
+      operationId: get_neki_role
+      summary: Get a Neki role
+      x-speakeasy-entity-operation: NekiBranchRole#read
+      x-speakeasy-entity-description: Returns information about a PlanetScale Neki branch role.
+
+  - target: $.paths['/organizations/{organization}/databases/{database}/branches/{branch}/roles/{id}#neki'].patch
+    update:
+      operationId: update_neki_role
+      summary: Update a Neki role
+      x-speakeasy-entity-operation: NekiBranchRole#update
+
+  - target: $.paths['/organizations/{organization}/databases/{database}/branches/{branch}/roles/{id}#neki'].delete
+    update:
+      operationId: delete_neki_role
+      summary: Delete a Neki role
+      x-speakeasy-entity-operation: NekiBranchRole#delete
+
+  - target: $.paths['/organizations/{organization}/databases/{database}/branches/{branch}/roles/{id}#neki'].get.responses['200'].content['application/json'].schema.properties.password
+    update:
+      x-speakeasy-param-sensitive: true
+      x-speakeasy-ignore: true
+
+  - target: $.paths['/organizations/{organization}/databases/{database}/branches/{branch}/roles/{id}#neki'].patch.responses['200'].content['application/json'].schema.properties.password
+    update:
+      x-speakeasy-param-sensitive: true
+      x-speakeasy-ignore: true
+
+  - target: $.paths['/organizations/{organization}/databases/{database}/branches/{branch}/roles#neki'].post.responses['200'].content['application/json'].schema.properties.password
+    update:
+      x-speakeasy-param-sensitive: true
+
+  - target: $.paths['/organizations/{organization}/databases/{database}/branches/{branch}/roles#neki'].post.requestBody.content['application/json'].schema.properties.inherited_roles
+    update:
+      format: set
+
+  - target: $.paths['/organizations/{organization}/databases/{database}/branches/{branch}/roles#neki'].post.responses['200'].content['application/json'].schema.properties.inherited_roles
+    update:
+      format: set
+
+  - target: $.paths['/organizations/{organization}/databases/{database}/branches/{branch}/roles/{id}#neki'].get.responses['200'].content['application/json'].schema.properties.inherited_roles
+    update:
+      format: set
+
+  - target: $.paths['/organizations/{organization}/databases/{database}/branches/{branch}/roles/{id}#neki'].patch.responses['200'].content['application/json'].schema.properties.inherited_roles
+    update:
+      format: set
+
+  - target: $.paths['/organizations/{organization}/databases/{database}/branches/{branch}/roles#neki'].post.responses['200'].content['application/json'].schema.properties.actor
+    update:
+      x-speakeasy-name-override: actor_data
+
+  - target: $.paths['/organizations/{organization}/databases/{database}/branches/{branch}/roles#neki'].post.responses['200'].content['application/json'].schema.properties.branch
+    update:
+      x-speakeasy-name-override: branch_data
+
+  - target: $.paths['/organizations/{organization}/databases/{database}/branches/{branch}/roles/{id}#neki'].get.responses['200'].content['application/json'].schema.properties.actor
+    update:
+      x-speakeasy-name-override: actor_data
+
+  - target: $.paths['/organizations/{organization}/databases/{database}/branches/{branch}/roles/{id}#neki'].get.responses['200'].content['application/json'].schema.properties.branch
+    update:
+      x-speakeasy-name-override: branch_data
+
+  - target: $.paths['/organizations/{organization}/databases/{database}/branches/{branch}/roles/{id}#neki'].patch.responses['200'].content['application/json'].schema.properties.actor
+    update:
+      x-speakeasy-name-override: actor_data
+
+  - target: $.paths['/organizations/{organization}/databases/{database}/branches/{branch}/roles/{id}#neki'].patch.responses['200'].content['application/json'].schema.properties.branch
+    update:
+      x-speakeasy-name-override: branch_data

--- a/schemas/overlay-terraform-neki-branch-roles.yaml
+++ b/schemas/overlay-terraform-neki-branch-roles.yaml
@@ -1,0 +1,41 @@
+overlay: 1.1.0
+x-speakeasy-jsonpath: rfc9535
+info:
+  title: Terraform generation overlay for planetscale_neki_branch_roles data source
+  version: 0.0.1
+actions:
+  - target: $.paths["/organizations/{organization}/databases/{database}/branches/{branch}/roles#neki"].get
+    update:
+      operationId: list_neki_roles
+      summary: List Neki roles
+      x-speakeasy-entity-operation: NekiBranchRoles#read
+      x-speakeasy-entity-description: Returns information about PlanetScale Neki branch roles.
+      x-speakeasy-pagination:
+        type: offsetLimit
+        inputs:
+          - name: page
+            in: parameters
+            type: page
+        outputs:
+          results: $.data
+
+  - target: $.paths["/organizations/{organization}/databases/{database}/branches/{branch}/roles#neki"].get.parameters[?@.name == 'per_page']
+    update:
+      x-speakeasy-terraform-ignore: true
+
+  - target: $.paths["/organizations/{organization}/databases/{database}/branches/{branch}/roles#neki"].get.responses["200"].content["application/json"].schema.properties
+    update:
+      current_page:
+        x-speakeasy-terraform-ignore: true
+      next_page:
+        x-speakeasy-terraform-ignore: true
+      next_page_url:
+        x-speakeasy-terraform-ignore: true
+      prev_page:
+        x-speakeasy-terraform-ignore: true
+      prev_page_url:
+        x-speakeasy-terraform-ignore: true
+
+  - target: $.paths["/organizations/{organization}/databases/{database}/branches/{branch}/roles#neki"].get.responses["200"].content["application/json"].schema.properties.data.items.properties.inherited_roles
+    update:
+      format: set

--- a/schemas/overlay-terraform-neki-branch.yaml
+++ b/schemas/overlay-terraform-neki-branch.yaml
@@ -1,0 +1,88 @@
+overlay: 1.1.0
+x-speakeasy-jsonpath: rfc9535
+info:
+  title: Terraform generation overlay for planetscale_neki_branch managed and data resources
+  version: 0.0.1
+actions:
+  - target: $.paths['/organizations/{organization}/databases/{database}/branches#neki'].post
+    description: Configure the Neki branch create operation.
+    update:
+      operationId: create_neki_branch
+      summary: Create a Neki branch
+      x-speakeasy-entity-operation: NekiBranch#create
+      x-speakeasy-entity-description: Manage a PlanetScale Neki database branch.
+
+  - target: $.paths['/organizations/{organization}/databases/{database}/branches#neki'].post.requestBody.content['application/json'].schema.properties
+    description: Transparently create Neki databases from branch resources.
+    update:
+      create_database_if_missing:
+        type: boolean
+        const: true
+        default: true
+        description: Create the database if it does not already exist.
+        x-speakeasy-terraform-ignore: schema
+      kind:
+        type: string
+        const: neki
+        default: neki
+        description: The kind of database. Always neki for planetscale_neki_branch.
+        x-speakeasy-terraform-ignore: schema
+
+  - target: $.paths['/organizations/{organization}/databases/{database}/branches#neki'].post.requestBody.content['application/json'].schema.properties.seed_data
+    description: Remove the Vitess-only seed option.
+    remove: true
+
+  - target: $.paths['/organizations/{organization}/databases/{database}/branches/{branch}#neki'].get
+    description: Configure Neki branch reads and creation polling.
+    update:
+      operationId: get_neki_branch
+      summary: Get a Neki branch
+      x-speakeasy-entity-operation:
+        - NekiBranch#read
+        - entityOperation: NekiBranch#create#2
+          options:
+            polling:
+              name: WaitForReady
+      x-speakeasy-entity-description: Returns information about a PlanetScale Neki database branch.
+      x-speakeasy-polling:
+        - name: WaitForReady
+          delaySeconds: 30
+          intervalSeconds: 10
+          limitCount: 90
+          successCriteria:
+            - condition: $statusCode == 200
+            - condition: $response.body#/state == "ready"
+
+  - target: $.paths['/organizations/{organization}/databases/{database}/branches/{branch}#neki'].patch
+    description: Configure Neki branch metadata updates.
+    update:
+      operationId: update_neki_branch
+      summary: Update a Neki branch
+      x-speakeasy-entity-operation: NekiBranch#update
+
+  - target: $.paths['/organizations/{organization}/databases/{database}/branches/{branch}#neki'].patch.parameters[?@.name == 'branch']
+    update:
+      x-speakeasy-match: id
+
+  - target: $.paths['/organizations/{organization}/databases/{database}/branches/{branch}#neki'].patch.requestBody.content['application/json'].schema.properties.new_name
+    update:
+      x-speakeasy-name-override: name
+
+  - target: $.paths['/organizations/{organization}/databases/{database}/branches/{branch}#neki'].delete
+    description: Configure Neki branch deletion.
+    update:
+      operationId: delete_neki_branch
+      summary: Delete a Neki branch
+      x-speakeasy-entity-operation: NekiBranch#delete
+
+  - target: $.paths['/organizations/{organization}/databases/{database}/branches#neki'].post.responses['201'].content['application/json'].schema.properties['mysql_address','mysql_edge_address','keyspace_count','vtgate_name','vtgate_count','vtgate_max_count','vtgate_autoscaling','vtgate_target_cpu_utilization']
+    description: Remove Vitess-only response fields.
+    remove: true
+
+  - target: $.paths['/organizations/{organization}/databases/{database}/branches/{branch}#neki'].get.responses['200'].content['application/json'].schema.properties['mysql_address','mysql_edge_address','keyspace_count','vtgate_name','vtgate_count','vtgate_max_count','vtgate_autoscaling','vtgate_target_cpu_utilization']
+    description: Remove Vitess-only response fields.
+    remove: true
+
+  - target: $.paths['/organizations/{organization}/databases/{database}/branches/{branch}#neki'].patch.responses['200'].content['application/json'].schema.properties['mysql_address','mysql_edge_address','keyspace_count','vtgate_name','vtgate_count','vtgate_max_count','vtgate_autoscaling','vtgate_target_cpu_utilization']
+    description: Remove Vitess-only response fields.
+    remove: true

--- a/schemas/overlay-terraform-neki-branch.yaml
+++ b/schemas/overlay-terraform-neki-branch.yaml
@@ -28,6 +28,10 @@ actions:
         description: The kind of database. Always neki for planetscale_neki_branch.
         x-speakeasy-terraform-ignore: schema
 
+  - target: $.paths['/organizations/{organization}/databases/{database}/branches#neki'].post.requestBody.content['application/json'].schema.properties.kind.enum
+    description: Remove the upstream mysql/postgresql enum; this path always sends the Neki const.
+    remove: true
+
   - target: $.paths['/organizations/{organization}/databases/{database}/branches#neki'].post.requestBody.content['application/json'].schema.properties.seed_data
     description: Remove the Vitess-only seed option.
     remove: true

--- a/schemas/overlay-terraform-neki-configuration-profile.yaml
+++ b/schemas/overlay-terraform-neki-configuration-profile.yaml
@@ -1,0 +1,84 @@
+overlay: 1.1.0
+x-speakeasy-jsonpath: rfc9535
+info:
+  title: Terraform generation overlay for planetscale_neki_configuration_profile managed and data resources
+  version: 0.0.1
+actions:
+  - target: $.components.schemas.NekiConfigurationProfile
+    update:
+      x-speakeasy-entity: NekiConfigurationProfile
+      x-speakeasy-entity-description: >-
+        Manage an additional Neki shard configuration profile on a branch.
+
+        Creating a `planetscale_neki_branch` already provisions a default
+        configuration profile. Import that profile if it needs to be managed;
+        do not attempt to create it again.
+
+  - target: $.components.schemas.NekiConfigurationProfile.properties.type
+    update:
+      x-speakeasy-terraform-ignore: true
+
+  - target: $.components.schemas.NekiConfigurationProfile.properties.default
+    update:
+      x-speakeasy-name-override: is_default
+
+  - target: $.components.schemas.NekiConfigurationProfile.properties['created_at','updated_at','cluster_display_name']
+    remove: true
+
+  - target: $.paths["/organizations/{organization}/databases/{database}/branches/{branch}/configuration-profiles"].post
+    update:
+      x-speakeasy-entity-operation: NekiConfigurationProfile#create
+      x-speakeasy-entity-description: >-
+        Manage an additional Neki shard configuration profile on a branch.
+        A branch's automatically created default profile should be imported
+        rather than created again.
+
+  - target: $.paths["/organizations/{organization}/databases/{database}/branches/{branch}/configuration-profiles"].post.parameters[?@.name == 'organization'].schema
+    update:
+      x-speakeasy-param-force-new: true
+
+  - target: $.paths["/organizations/{organization}/databases/{database}/branches/{branch}/configuration-profiles"].post.parameters[?@.name == 'database'].schema
+    update:
+      x-speakeasy-param-force-new: true
+
+  - target: $.paths["/organizations/{organization}/databases/{database}/branches/{branch}/configuration-profiles"].post.parameters[?@.name == 'branch'].schema
+    update:
+      x-speakeasy-param-force-new: true
+
+  - target: $.paths["/organizations/{organization}/databases/{database}/branches/{branch}/configuration-profiles/{configuration_profile}"].get
+    update:
+      x-speakeasy-entity-operation:
+        - NekiConfigurationProfile#read
+        - entityOperation: NekiConfigurationProfile#create#2
+          options:
+            polling:
+              name: WaitForReady
+        - entityOperation: NekiConfigurationProfile#update#2
+          options:
+            polling:
+              name: WaitForReady
+      x-speakeasy-entity-description: Returns a Neki shard configuration profile.
+      x-speakeasy-polling:
+        - name: WaitForReady
+          delaySeconds: 10
+          intervalSeconds: 10
+          limitCount: 180
+          successCriteria:
+            - condition: $statusCode == 200
+            - condition: $response.body#/state == "ready"
+
+  - target: $.paths["/organizations/{organization}/databases/{database}/branches/{branch}/configuration-profiles/{configuration_profile}"].patch
+    update:
+      x-speakeasy-entity-operation: NekiConfigurationProfile#update
+
+  - target: $.paths["/organizations/{organization}/databases/{database}/branches/{branch}/configuration-profiles/{configuration_profile}"].delete
+    update:
+      x-speakeasy-entity-operation: NekiConfigurationProfile#delete
+
+  - target: $.paths["/organizations/{organization}/databases/{database}/branches/{branch}/configuration-profiles/{configuration_profile}"].*.parameters[?@.name == 'configuration_profile']
+    update:
+      x-speakeasy-match: name
+
+  - target: $.paths["/organizations/{organization}/databases/{database}/branches/{branch}/configuration-profiles/{configuration_profile}"].patch.requestBody.content["application/json"].schema.properties.name
+    update:
+      x-speakeasy-name-override: name

--- a/schemas/overlay-terraform-neki-configuration-profiles.yaml
+++ b/schemas/overlay-terraform-neki-configuration-profiles.yaml
@@ -1,0 +1,15 @@
+overlay: 1.1.0
+x-speakeasy-jsonpath: rfc9535
+info:
+  title: Terraform generation overlay for planetscale_neki_configuration_profiles data source
+  version: 0.0.1
+actions:
+  - target: $.paths["/organizations/{organization}/databases/{database}/branches/{branch}/configuration-profiles"].get
+    update:
+      x-speakeasy-entity-operation: NekiConfigurationProfiles#read
+      x-speakeasy-entity-description: Returns Neki shard configuration profiles for a branch.
+
+  - target: $.paths["/organizations/{organization}/databases/{database}/branches/{branch}/configuration-profiles"].get.responses["200"].content["application/json"].schema
+    update:
+      x-speakeasy-entity: NekiConfigurationProfiles
+      x-speakeasy-entity-description: Returns Neki shard configuration profiles for a branch.

--- a/schemas/overlay-terraform-neki-redacted-branch-role.yaml
+++ b/schemas/overlay-terraform-neki-redacted-branch-role.yaml
@@ -1,0 +1,59 @@
+overlay: 1.1.0
+x-speakeasy-jsonpath: rfc9535
+info:
+  title: Terraform generation overlay for planetscale_neki_redacted_branch_role managed resource
+  version: 0.0.1
+actions:
+  - target: $.paths
+    update:
+      /organizations/{organization}/databases/{database}/branches/{branch}/roles#neki-redacted: {}
+
+  - target: $.paths['/organizations/{organization}/databases/{database}/branches/{branch}/roles#neki-redacted']
+    copy: $.paths['/organizations/{organization}/databases/{database}/branches/{branch}/roles#neki']
+
+  - target: $.paths
+    update:
+      /organizations/{organization}/databases/{database}/branches/{branch}/roles/{id}#neki-redacted: {}
+
+  - target: $.paths['/organizations/{organization}/databases/{database}/branches/{branch}/roles/{id}#neki-redacted']
+    copy: $.paths['/organizations/{organization}/databases/{database}/branches/{branch}/roles/{id}#neki']
+
+  - target: $.paths['/organizations/{organization}/databases/{database}/branches/{branch}/roles#neki-redacted'].get
+    remove: true
+
+  - target: $.paths['/organizations/{organization}/databases/{database}/branches/{branch}/roles#neki-redacted'].post
+    update:
+      operationId: create_neki_redacted_role
+      summary: Create a Neki role without retaining its password
+      x-speakeasy-entity-operation: NekiRedactedBranchRole#create
+      x-speakeasy-entity-description: Manage a PlanetScale Neki branch role without storing its password in Terraform state.
+
+  - target: $.paths['/organizations/{organization}/databases/{database}/branches/{branch}/roles/{id}#neki-redacted'].get
+    update:
+      operationId: get_neki_redacted_role
+      summary: Get a Neki role without a password
+      x-speakeasy-entity-operation: NekiRedactedBranchRole#read
+
+  - target: $.paths['/organizations/{organization}/databases/{database}/branches/{branch}/roles/{id}#neki-redacted'].patch
+    update:
+      operationId: update_neki_redacted_role
+      summary: Update a redacted Neki role
+      x-speakeasy-entity-operation: NekiRedactedBranchRole#update
+
+  - target: $.paths['/organizations/{organization}/databases/{database}/branches/{branch}/roles/{id}#neki-redacted'].delete
+    update:
+      operationId: delete_neki_redacted_role
+      summary: Delete a redacted Neki role
+      x-speakeasy-entity-operation: NekiRedactedBranchRole#delete
+
+  - target: $.paths['/organizations/{organization}/databases/{database}/branches/{branch}/roles/{id}#neki-redacted'].get.responses["200"].content["application/json"].schema.properties.password
+    update:
+      x-speakeasy-terraform-ignore: true
+
+  - target: $.paths['/organizations/{organization}/databases/{database}/branches/{branch}/roles/{id}#neki-redacted'].patch.responses["200"].content["application/json"].schema.properties.password
+    update:
+      x-speakeasy-terraform-ignore: true
+
+  - target: $.paths['/organizations/{organization}/databases/{database}/branches/{branch}/roles#neki-redacted'].post.responses["200"].content["application/json"].schema.properties.password
+    update:
+      x-speakeasy-terraform-ignore: true


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add overlay definitions for Neki branches and related resources
- add acceptance coverage gated by `PLANETSCALE_NEKI_ENABLED=true`
- keep all Neki overlays commented out in the normal Speakeasy workflow so released provider schemas remain unchanged
- allow developers to opt in locally by uncommenting the lines marked `Neki preview` and running `make generate`

## API status
The live API implementation is expected to accept `kind: neki`, but the published OpenAPI currently limits `kind` to `mysql` and `postgresql` and omits Neki configuration-profile operations. The preview overlays bridge those documentation gaps until the upstream schema includes them.

## Testing
Testing is in progress. The default workflow will be checked for zero Neki schema exposure, followed by preview generation and unit tests with the dormant lines enabled.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c8b4a89a-743c-46e6-966f-c73c33bdcbfc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c8b4a89a-743c-46e6-966f-c73c33bdcbfc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

