### PR TITLE
Add development-only Neki branch support

### DIFF
--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -8,8 +8,10 @@ sources:
             - location: schemas/overlay-terraform.yaml
 
             - location: schemas/overlay-terraform-branches.yaml
+            # - location: schemas/overlay-terraform-neki-branches.yaml
             - location: schemas/overlay-terraform-postgres-branch.yaml
             - location: schemas/overlay-terraform-vitess-branch.yaml
+            # - location: schemas/overlay-terraform-neki-branch.yaml
 
             - location: schemas/overlay-terraform-database_vitess.yaml
             - location: schemas/overlay-terraform-database_postgres.yaml

--- a/internal/provider/nekibranch_resource_test.go
+++ b/internal/provider/nekibranch_resource_test.go
@@ -1,0 +1,74 @@
+package provider
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+func TestAccNekiBranchResource_Lifecycle(t *testing.T) {
+	t.Parallel()
+
+	databaseName := randomWithPrefix("testacc-neki")
+	branchNameOriginal := "main"
+	branchNameRenamed := randomWithPrefix("main-renamed")
+	resourceAddress := "planetscale_neki_branch.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccNekiPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders(),
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.TestNameDirectory(),
+				ConfigVariables: config.Variables{
+					"organization":  config.StringVariable(testAccOrg),
+					"database_name": config.StringVariable(databaseName),
+					"branch_name":   config.StringVariable(branchNameOriginal),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceAddress, tfjsonpath.New("id"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceAddress, tfjsonpath.New("name"), knownvalue.StringExact(branchNameOriginal)),
+					statecheck.ExpectKnownValue(resourceAddress, tfjsonpath.New("state"), knownvalue.StringExact("ready")),
+				},
+			},
+			{
+				ConfigDirectory: config.TestNameDirectory(),
+				ConfigVariables: config.Variables{
+					"organization":  config.StringVariable(testAccOrg),
+					"database_name": config.StringVariable(databaseName),
+					"branch_name":   config.StringVariable(branchNameRenamed),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceAddress, tfjsonpath.New("name"), knownvalue.StringExact(branchNameRenamed)),
+					statecheck.ExpectKnownValue(resourceAddress, tfjsonpath.New("state"), knownvalue.StringExact("ready")),
+				},
+			},
+			{
+				ConfigDirectory: config.TestNameDirectory(),
+				ConfigVariables: config.Variables{
+					"organization":  config.StringVariable(testAccOrg),
+					"database_name": config.StringVariable(databaseName),
+					"branch_name":   config.StringVariable(branchNameRenamed),
+				},
+				ResourceName: resourceAddress,
+				ImportState:  true,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					rs := s.RootModule().Resources[resourceAddress]
+					jsonBytes, err := json.Marshal(map[string]string{
+						"database":     rs.Primary.Attributes["database"],
+						"id":           rs.Primary.Attributes["id"],
+						"organization": rs.Primary.Attributes["organization"],
+					})
+					return string(jsonBytes), err
+				},
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	frameworkresource "github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/planetscale/terraform-provider-planetscale/internal/sdk"
 	"github.com/planetscale/terraform-provider-planetscale/internal/sdk/models/operations"
@@ -40,6 +41,29 @@ func testAccPreCheck(t *testing.T) {
 	}
 
 	t.Fatal("Both PLANETSCALE_SERVICE_TOKEN and PLANETSCALE_SERVICE_TOKEN_ID must be set for acceptance tests")
+}
+
+func testAccNekiPreCheck(t *testing.T) {
+	t.Helper()
+	if !testAccResourceRegistered("planetscale_neki_branch") {
+		t.Skip("skipping Neki acceptance test: planetscale_neki_branch is not generated")
+	}
+	testAccPreCheck(t)
+}
+
+func testAccResourceRegistered(typeName string) bool {
+	ctx := context.Background()
+	provider := &PlanetscaleProvider{version: "test"}
+	for _, factory := range provider.Resources(ctx) {
+		var metadata frameworkresource.MetadataResponse
+		factory().Metadata(ctx, frameworkresource.MetadataRequest{
+			ProviderTypeName: "planetscale",
+		}, &metadata)
+		if metadata.TypeName == typeName {
+			return true
+		}
+	}
+	return false
 }
 
 // randomWithPrefix generates a random string with the given prefix.

--- a/internal/provider/testdata/TestAccNekiBranchResource_Lifecycle/main.tf
+++ b/internal/provider/testdata/TestAccNekiBranchResource_Lifecycle/main.tf
@@ -1,0 +1,17 @@
+variable "organization" {
+  type = string
+}
+
+variable "database_name" {
+  type = string
+}
+
+variable "branch_name" {
+  type = string
+}
+
+resource "planetscale_neki_branch" "test" {
+  organization = var.organization
+  database     = var.database_name
+  name         = var.branch_name
+}

--- a/schemas/overlay-terraform-neki-branch.yaml
+++ b/schemas/overlay-terraform-neki-branch.yaml
@@ -1,0 +1,106 @@
+overlay: 1.1.0
+x-speakeasy-jsonpath: rfc9535
+info:
+  title: Terraform generation overlay for planetscale_neki_branch
+  version: 0.0.1
+actions:
+  - target: $.paths['/organizations/{organization}/databases/{database}/branches#neki'].post
+    update:
+      operationId: create_neki_branch
+      summary: Create a Neki branch
+      x-speakeasy-entity-operation: NekiBranch#create
+      x-speakeasy-entity-description: >-
+        Manage a PlanetScale Neki database branch.
+
+  - target: $.paths['/organizations/{organization}/databases/{database}/branches#neki'].post.parameters[?@.name == 'organization'].schema
+    description: Moving a branch to another organization requires replacement.
+    update:
+      x-speakeasy-param-force-new: true
+
+  - target: $.paths['/organizations/{organization}/databases/{database}/branches#neki'].post.parameters[?@.name == 'database'].schema
+    description: Moving a branch to another database requires replacement.
+    update:
+      x-speakeasy-param-force-new: true
+
+  - target: $.paths['/organizations/{organization}/databases/{database}/branches#neki'].post.requestBody.content['application/json'].schema.properties
+    update:
+      create_database_if_missing:
+        type: boolean
+        const: true
+        default: true
+        description: Create the database if it does not already exist.
+        x-speakeasy-terraform-ignore: schema
+      kind:
+        type: string
+        const: neki
+        default: neki
+        description: The database kind. Always neki for planetscale_neki_branch.
+        x-speakeasy-terraform-ignore: schema
+
+  - target: $.paths['/organizations/{organization}/databases/{database}/branches#neki'].post.requestBody.content['application/json'].schema.properties.kind.enum
+    description: Remove the upstream mysql/postgresql enum because this path always sends the Neki const.
+    remove: true
+
+  - target: $.paths['/organizations/{organization}/databases/{database}/branches#neki'].post.requestBody.content['application/json'].schema.properties.seed_data
+    description: Remove the Vitess-only seed option.
+    remove: true
+
+  - target: $.paths['/organizations/{organization}/databases/{database}/branches#neki'].post.requestBody.content['application/json'].schema.properties['cluster_size','major_version']
+    description: Configuration profiles own cluster size and PostgreSQL version.
+    remove: true
+
+  - target: $.paths['/organizations/{organization}/databases/{database}/branches#neki'].post.requestBody.content['application/json'].schema.properties.restore_point
+    update:
+      description: Restore the Neki branch from a point-in-time recovery timestamp, for example 2026-01-01T00:00:00Z.
+
+  - target: $.paths['/organizations/{organization}/databases/{database}/branches/{branch}#neki'].get
+    update:
+      operationId: get_neki_branch
+      summary: Get a Neki branch
+      x-speakeasy-entity-operation:
+        - NekiBranch#read
+        - entityOperation: NekiBranch#create#2
+          options:
+            polling:
+              name: WaitForReady
+      x-speakeasy-entity-description: Returns information about a PlanetScale Neki database branch.
+      x-speakeasy-polling:
+        - name: WaitForReady
+          delaySeconds: 30
+          intervalSeconds: 10
+          limitCount: 90
+          successCriteria:
+            - condition: $statusCode == 200
+            - condition: $response.body#/state == "ready"
+
+  - target: $.paths['/organizations/{organization}/databases/{database}/branches/{branch}#neki'].patch
+    update:
+      operationId: update_neki_branch
+      summary: Update a Neki branch
+      x-speakeasy-entity-operation: NekiBranch#update
+
+  - target: $.paths['/organizations/{organization}/databases/{database}/branches/{branch}#neki'].patch.parameters[?@.name == 'branch']
+    update:
+      x-speakeasy-match: id
+
+  - target: $.paths['/organizations/{organization}/databases/{database}/branches/{branch}#neki'].patch.requestBody.content['application/json'].schema.properties.new_name
+    update:
+      x-speakeasy-name-override: name
+
+  - target: $.paths['/organizations/{organization}/databases/{database}/branches/{branch}#neki'].delete
+    update:
+      operationId: delete_neki_branch
+      summary: Delete a Neki branch
+      x-speakeasy-entity-operation: NekiBranch#delete
+
+  - target: $.paths['/organizations/{organization}/databases/{database}/branches#neki'].post.responses['201'].content['application/json'].schema.properties['actor','cluster_name','html_url','mysql_address','mysql_edge_address','keyspace_count','ready','region','safe_migrations','url','vtgate_name','vtgate_count','vtgate_max_count','vtgate_autoscaling','vtgate_target_cpu_utilization']
+    description: Keep only critical Neki branch state and remove engine-specific or convenience metadata.
+    remove: true
+
+  - target: $.paths['/organizations/{organization}/databases/{database}/branches/{branch}#neki'].get.responses['200'].content['application/json'].schema.properties['actor','cluster_name','html_url','mysql_address','mysql_edge_address','keyspace_count','ready','region','safe_migrations','url','vtgate_name','vtgate_count','vtgate_max_count','vtgate_autoscaling','vtgate_target_cpu_utilization']
+    description: Keep only critical Neki branch state and remove engine-specific or convenience metadata.
+    remove: true
+
+  - target: $.paths['/organizations/{organization}/databases/{database}/branches/{branch}#neki'].patch.responses['200'].content['application/json'].schema.properties['actor','cluster_name','html_url','mysql_address','mysql_edge_address','keyspace_count','ready','region','safe_migrations','url','vtgate_name','vtgate_count','vtgate_max_count','vtgate_autoscaling','vtgate_target_cpu_utilization']
+    description: Keep only critical Neki branch state and remove engine-specific or convenience metadata.
+    remove: true

--- a/schemas/overlay-terraform-neki-branches.yaml
+++ b/schemas/overlay-terraform-neki-branches.yaml
@@ -1,0 +1,21 @@
+overlay: 1.1.0
+x-speakeasy-jsonpath: rfc9535
+info:
+  title: Path split for Neki branch resources
+  version: 0.0.1
+actions:
+  - target: $.paths
+    update:
+      /organizations/{organization}/databases/{database}/branches#neki: {}
+
+  - target: $.paths['/organizations/{organization}/databases/{database}/branches#neki']
+    description: Copy the normalized branch collection path as the base for Neki.
+    copy: $.paths['/organizations/{organization}/databases/{database}/branches#postgres']
+
+  - target: $.paths
+    update:
+      /organizations/{organization}/databases/{database}/branches/{branch}#neki: {}
+
+  - target: $.paths['/organizations/{organization}/databases/{database}/branches/{branch}#neki']
+    description: Copy the normalized branch item path as the base for Neki.
+    copy: $.paths['/organizations/{organization}/databases/{database}/branches/{branch}#postgres']


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds Neki branch overlays and lifecycle acceptance coverage while keeping the resource out of normal provider generation. We can uncomment the two workflow entries and regenerate the provider to test branch creation against development.

```hcl
resource "planetscale_neki_branch" "example" {
  organization       = "big-bang"
  database           = "my-neki-database"
  name               = "main"
  deletion_protected = true
}
```

Neki configuration profiles own cluster size, replicas, PostgreSQL version, parameters, and extensions. The branch resource owns identity, lineage, region, restore inputs, and deletion protection. This is the first slice of Neki Terraform support. Configuration profiles and other Neki resources come next.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-010656af-ba3c-4d4c-b534-c5633876a81d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-010656af-ba3c-4d4c-b534-c5633876a81d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

