### PR TITLE
Wait longer for PostgreSQL branch restores

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -1,7 +1,7 @@
 lockVersion: 2.0.0
 id: 156e2223-c8d0-4591-922d-3e4c474de609
 management:
-  docChecksum: 08d597de19d8ef6fc57d410edbaf7859
+  docChecksum: 19e0887c8844552fc209b337f7f184a5
   docVersion: v1
   speakeasyVersion: 1.793.0
   generationVersion: 2.928.0

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -2,8 +2,8 @@ speakeasyVersion: 1.793.0
 sources:
     PlanetScale API:
         sourceNamespace: planet-scale-api
-        sourceRevisionDigest: sha256:ab9c0431ff41e3d1baaed49858dd257b190b9a9a24929e61a443205d1ea5a908
-        sourceBlobDigest: sha256:d35eb56a8cb9656a59cdd1959c63fb672c26452bc0e8ca3cc27c408978b0bc15
+        sourceRevisionDigest: sha256:d5089612424f0664bd2d7e613fc4fe1432cb3daa422b29c72b4679aa20e2c061
+        sourceBlobDigest: sha256:a6a5ac3741c4b13539d1cdb8009e59ef0d56649be164e12ee9465a7be919a1f6
         tags:
             - latest
             - v1
@@ -11,8 +11,8 @@ targets:
     planetscale:
         source: PlanetScale API
         sourceNamespace: planet-scale-api
-        sourceRevisionDigest: sha256:ab9c0431ff41e3d1baaed49858dd257b190b9a9a24929e61a443205d1ea5a908
-        sourceBlobDigest: sha256:d35eb56a8cb9656a59cdd1959c63fb672c26452bc0e8ca3cc27c408978b0bc15
+        sourceRevisionDigest: sha256:d5089612424f0664bd2d7e613fc4fe1432cb3daa422b29c72b4679aa20e2c061
+        sourceBlobDigest: sha256:a6a5ac3741c4b13539d1cdb8009e59ef0d56649be164e12ee9465a7be919a1f6
 workflow:
     workflowVersion: 1.0.0
     speakeasyVersion: 1.793.0

--- a/internal/sdk/databasebranches.go
+++ b/internal/sdk/databasebranches.go
@@ -492,7 +492,7 @@ func (s *DatabaseBranches) GetPostgresBranchWaitForReady() polling.ConfigFunc {
 	return func(pollingOpts ...polling.Option) (*polling.Config, error) {
 		defaultDelaySeconds := 30
 		defaultIntervalSeconds := 10
-		defaultLimitCount := 90
+		defaultLimitCount := 4320
 		result := &polling.Config{
 			DelaySeconds:    &defaultDelaySeconds,
 			IntervalSeconds: &defaultIntervalSeconds,

--- a/schemas/out.openapi.yaml
+++ b/schemas/out.openapi.yaml
@@ -5866,7 +5866,7 @@ paths:
         - name: WaitForReady
           delaySeconds: 30
           intervalSeconds: 10
-          limitCount: 90 # 15 minutes at a 10 second interval, plus initial 30 second delay
+          limitCount: 4320 # 12 hours at a 10 second interval, plus initial 30 second delay
           successCriteria:
             - condition: $statusCode == 200
             - condition: $response.body#/state == "ready"

--- a/schemas/overlay-terraform-postgres-branch.yaml
+++ b/schemas/overlay-terraform-postgres-branch.yaml
@@ -59,7 +59,7 @@ actions:
         - name: WaitForReady
           delaySeconds: 30
           intervalSeconds: 10
-          limitCount: 90 # 15 minutes at a 10 second interval, plus initial 30 second delay
+          limitCount: 4320 # 12 hours at a 10 second interval, plus initial 30 second delay
           successCriteria:
             - condition: $statusCode == 200
             - condition: $response.body#/state == "ready"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Terraform currently stops waiting while PlanetScale continues restoring larger PostgreSQL branches. This change lets Terraform wait up to 12 hours for the branch to become ready.

Closes [#334](https://github.com/planetscale/terraform-provider-planetscale/issues/334)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eeff9c1f-5fc0-4b12-ad3b-d05dc5c71157?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eeff9c1f-5fc0-4b12-ad3b-d05dc5c71157&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

