### PR TITLE
Prevent replacement of imported Postgres branches

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
           go-version-file: "go.mod"
       - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
         with:
-          terraform_version: 1.9.*
+          terraform_version: 1.11.*
           terraform_wrapper: false
       - run: go generate -x ./...
       - name: git diff

--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -1,12 +1,16 @@
 lockVersion: 2.0.0
 id: 156e2223-c8d0-4591-922d-3e4c474de609
 management:
+<<<<<<< HEAD
   docChecksum: 845c7c2c5e617c10afd737e441029001
+=======
+  docChecksum: 4b3dafa8899c1cda9ade6e2307d1c3d2
+>>>>>>> 001e0bd (make generate)
   docVersion: v1
   speakeasyVersion: 1.793.0
   generationVersion: 2.928.0
-  releaseVersion: 1.8.0
-  configChecksum: f26063e122d67bffa72f5e8f9e7a5384
+  releaseVersion: 1.11.0
+  configChecksum: fbca83d7ddcdff365077535f4236e5d8
 persistentEdits:
   generation_id: 60e31278-cdaa-4542-9c58-f63a48b53d1a
   pristine_commit_hash: 0f48b87acc4799dd3898ffc3569dccdf1e31fb15

--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -1,11 +1,7 @@
 lockVersion: 2.0.0
 id: 156e2223-c8d0-4591-922d-3e4c474de609
 management:
-<<<<<<< HEAD
-  docChecksum: 845c7c2c5e617c10afd737e441029001
-=======
-  docChecksum: 4b3dafa8899c1cda9ade6e2307d1c3d2
->>>>>>> 001e0bd (make generate)
+  docChecksum: 8edf47ae8b655cfa70ba058941f05184
   docVersion: v1
   speakeasyVersion: 1.793.0
   generationVersion: 2.928.0

--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -1,7 +1,7 @@
 lockVersion: 2.0.0
 id: 156e2223-c8d0-4591-922d-3e4c474de609
 management:
-  docChecksum: 19e0887c8844552fc209b337f7f184a5
+  docChecksum: 845c7c2c5e617c10afd737e441029001
   docVersion: v1
   speakeasyVersion: 1.793.0
   generationVersion: 2.928.0
@@ -2258,7 +2258,7 @@ examples:
           branch: "<value>"
       responses:
         "200":
-          application/json: {"id": "<id>", "name": "<value>", "state": "awakening", "cluster_name": "<value>", "ready": true, "deletion_protected": true, "actor": {"id": "<id>"}, "html_url": "https://unsung-pliers.info/", "url": "https://all-tool.name/", "region": {"id": "<id>", "mysql_supported": true, "postgresql_supported": false}, "parent_branch": "<value>"}
+          application/json: {"id": "<id>", "name": "<value>", "state": "awakening", "cluster_name": "<value>", "ready": true, "deletion_protected": true, "actor": {"id": "<id>"}, "html_url": "https://unsung-pliers.info/", "url": "https://all-tool.name/", "region": {"id": "<id>", "mysql_supported": true, "postgresql_supported": false}, "parent_branch": "<value>", "region_slug": "<value>"}
   delete_postgres_branch:
     speakeasy-default-delete-postgres-branch:
       parameters:

--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -32,7 +32,7 @@ generation:
     generateNewTests: true
     skipResponseBodyAssertions: false
 terraform:
-  version: 1.8.0
+  version: 1.11.0
   additionalActions: []
   additionalDataSources: []
   additionalDependencies: []

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -2,8 +2,8 @@ speakeasyVersion: 1.793.0
 sources:
     PlanetScale API:
         sourceNamespace: planet-scale-api
-        sourceRevisionDigest: sha256:d5089612424f0664bd2d7e613fc4fe1432cb3daa422b29c72b4679aa20e2c061
-        sourceBlobDigest: sha256:a6a5ac3741c4b13539d1cdb8009e59ef0d56649be164e12ee9465a7be919a1f6
+        sourceRevisionDigest: sha256:6e525f9a2bb948ba3055171d44017c258b4ad163749580f4d9cce4b4fdd3e578
+        sourceBlobDigest: sha256:242f257685327fb453034c0e98f5a5b52bbc0317cf9a073be9ffafa07ccaccc5
         tags:
             - latest
             - v1
@@ -11,8 +11,8 @@ targets:
     planetscale:
         source: PlanetScale API
         sourceNamespace: planet-scale-api
-        sourceRevisionDigest: sha256:d5089612424f0664bd2d7e613fc4fe1432cb3daa422b29c72b4679aa20e2c061
-        sourceBlobDigest: sha256:a6a5ac3741c4b13539d1cdb8009e59ef0d56649be164e12ee9465a7be919a1f6
+        sourceRevisionDigest: sha256:6e525f9a2bb948ba3055171d44017c258b4ad163749580f4d9cce4b4fdd3e578
+        sourceBlobDigest: sha256:242f257685327fb453034c0e98f5a5b52bbc0317cf9a073be9ffafa07ccaccc5
 workflow:
     workflowVersion: 1.0.0
     speakeasyVersion: 1.793.0

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -2,13 +2,8 @@ speakeasyVersion: 1.793.0
 sources:
     PlanetScale API:
         sourceNamespace: planet-scale-api
-<<<<<<< HEAD
-        sourceRevisionDigest: sha256:6e525f9a2bb948ba3055171d44017c258b4ad163749580f4d9cce4b4fdd3e578
-        sourceBlobDigest: sha256:242f257685327fb453034c0e98f5a5b52bbc0317cf9a073be9ffafa07ccaccc5
-=======
-        sourceRevisionDigest: sha256:bf83f9d37ad796742fed0fbf68612069c63bfa27d71156072b83753a25ac2e4e
-        sourceBlobDigest: sha256:77d3b9c2bc685a47b85533698350ae0f6fdfbe40f4aee79292b886cdb5e60421
->>>>>>> 001e0bd (make generate)
+        sourceRevisionDigest: sha256:9ae57c93c362ff67582ec076b819d0a8de6fe0dbc91b4d4552f2a011d927c056
+        sourceBlobDigest: sha256:d68c2341875890e7fa5e856f93429a636316cbe4f9eac632f13bf952f8ac0f7f
         tags:
             - latest
             - v1
@@ -16,13 +11,8 @@ targets:
     planetscale:
         source: PlanetScale API
         sourceNamespace: planet-scale-api
-<<<<<<< HEAD
-        sourceRevisionDigest: sha256:6e525f9a2bb948ba3055171d44017c258b4ad163749580f4d9cce4b4fdd3e578
-        sourceBlobDigest: sha256:242f257685327fb453034c0e98f5a5b52bbc0317cf9a073be9ffafa07ccaccc5
-=======
-        sourceRevisionDigest: sha256:bf83f9d37ad796742fed0fbf68612069c63bfa27d71156072b83753a25ac2e4e
-        sourceBlobDigest: sha256:77d3b9c2bc685a47b85533698350ae0f6fdfbe40f4aee79292b886cdb5e60421
->>>>>>> 001e0bd (make generate)
+        sourceRevisionDigest: sha256:9ae57c93c362ff67582ec076b819d0a8de6fe0dbc91b4d4552f2a011d927c056
+        sourceBlobDigest: sha256:d68c2341875890e7fa5e856f93429a636316cbe4f9eac632f13bf952f8ac0f7f
 workflow:
     workflowVersion: 1.0.0
     speakeasyVersion: 1.793.0

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -2,8 +2,13 @@ speakeasyVersion: 1.793.0
 sources:
     PlanetScale API:
         sourceNamespace: planet-scale-api
+<<<<<<< HEAD
         sourceRevisionDigest: sha256:6e525f9a2bb948ba3055171d44017c258b4ad163749580f4d9cce4b4fdd3e578
         sourceBlobDigest: sha256:242f257685327fb453034c0e98f5a5b52bbc0317cf9a073be9ffafa07ccaccc5
+=======
+        sourceRevisionDigest: sha256:bf83f9d37ad796742fed0fbf68612069c63bfa27d71156072b83753a25ac2e4e
+        sourceBlobDigest: sha256:77d3b9c2bc685a47b85533698350ae0f6fdfbe40f4aee79292b886cdb5e60421
+>>>>>>> 001e0bd (make generate)
         tags:
             - latest
             - v1
@@ -11,8 +16,13 @@ targets:
     planetscale:
         source: PlanetScale API
         sourceNamespace: planet-scale-api
+<<<<<<< HEAD
         sourceRevisionDigest: sha256:6e525f9a2bb948ba3055171d44017c258b4ad163749580f4d9cce4b4fdd3e578
         sourceBlobDigest: sha256:242f257685327fb453034c0e98f5a5b52bbc0317cf9a073be9ffafa07ccaccc5
+=======
+        sourceRevisionDigest: sha256:bf83f9d37ad796742fed0fbf68612069c63bfa27d71156072b83753a25ac2e4e
+        sourceBlobDigest: sha256:77d3b9c2bc685a47b85533698350ae0f6fdfbe40f4aee79292b886cdb5e60421
+>>>>>>> 001e0bd (make generate)
 workflow:
     workflowVersion: 1.0.0
     speakeasyVersion: 1.793.0

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ terraform {
   required_providers {
     planetscale = {
       source  = "planetscale/planetscale"
-      version = "1.8.0"
+      version = "1.11.0"
     }
   }
 }

--- a/docs/data-sources/postgres_branch.md
+++ b/docs/data-sources/postgres_branch.md
@@ -39,6 +39,7 @@ data "planetscale_postgres_branch" "my_postgresbranch" {
 - `parameters` (Map of Map of String) Postgres parameter overrides, nested by namespace (pgconf, pgbouncer, patroni), e.g. { pgconf = { max_connections = "200" } }. Omitted parameters are reset to their defaults.
 - `parent_branch` (String) The name of the parent branch from which the branch was created
 - `ready` (Boolean) Whether or not the branch is ready to serve queries
+- `region` (String) The region slug where the branch is hosted.
 - `region_data` (Attributes) (see [below for nested schema](#nestedatt--region_data))
 - `replicas` (Number) The number of replicas for the branch
 - `state` (String) The current state of the branch

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ terraform {
   required_providers {
     planetscale = {
       source  = "planetscale/planetscale"
-      version = "1.8.0"
+      version = "1.11.0"
     }
   }
 }

--- a/docs/resources/postgres_branch.md
+++ b/docs/resources/postgres_branch.md
@@ -42,7 +42,9 @@ resource "planetscale_postgres_branch" "my_postgresbranch" {
 
 ### Optional
 
-- `backup_id` (String) If provided, restores the backup's schema and data to the new branch. Must have `restore_production_branch_backup(s)` or `restore_backup(s)` access to do this. Requires replacement if changed.
+> **NOTE**: [Write-only arguments](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments) are supported in Terraform 1.11 and later.
+
+- `backup_id` (String, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) If provided, restores the backup's schema and data to the new branch. Must have `restore_production_branch_backup(s)` or `restore_backup(s)` access to do this. Requires replacement if changed.
 - `cluster_size` (String) The size of the cluster. Available sizes can be found using the 'List cluster sizes' endpoint.
 - `delete_descendants` (Boolean) If true, recursively delete all descendant branches along with this branch
 - `deletion_protected` (Boolean) Whether deletion protection is enabled for the branch
@@ -50,7 +52,7 @@ resource "planetscale_postgres_branch" "my_postgresbranch" {
 - `parameters` (Map of Map of String) Postgres parameter overrides, nested by namespace (pgconf, pgbouncer, patroni), e.g. { pgconf = { max_connections = "200" } }. Omitted parameters are reset to their defaults.
 - `parent_branch` (String) The name of the parent branch. Defaults to the database's default branch if not provided. Requires replacement if changed.
 - `region` (String) The region to create the branch in. If not provided, the branch will be created in the default region for its database. Requires replacement if changed.
-- `restore_point` (String) Restore from a point-in-time recovery timestamp (e.g. 2023-01-01T00:00:00Z). Available only for PostgreSQL databases. Requires replacement if changed.
+- `restore_point` (String, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) Restore from a point-in-time recovery timestamp (e.g. 2023-01-01T00:00:00Z). Available only for PostgreSQL databases. Requires replacement if changed.
 
 ### Read-Only
 

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     planetscale = {
       source  = "planetscale/planetscale"
-      version = "1.8.0"
+      version = "1.11.0"
     }
   }
 }

--- a/internal/provider/postgresbranch_data_source.go
+++ b/internal/provider/postgresbranch_data_source.go
@@ -40,6 +40,7 @@ type PostgresBranchDataSourceModel struct {
 	Parameters        map[string]map[string]types.String   `tfsdk:"parameters"`
 	ParentBranch      types.String                         `tfsdk:"parent_branch"`
 	Ready             types.Bool                           `tfsdk:"ready"`
+	Region            types.String                         `tfsdk:"region"`
 	RegionData        *tfTypes.GetPostgresBranchRegionData `tfsdk:"region_data"`
 	Replicas          types.Int64                          `tfsdk:"replicas"`
 	State             types.String                         `tfsdk:"state"`
@@ -108,6 +109,10 @@ func (r *PostgresBranchDataSource) Schema(ctx context.Context, req datasource.Sc
 			"ready": schema.BoolAttribute{
 				Computed:    true,
 				Description: `Whether or not the branch is ready to serve queries`,
+			},
+			"region": schema.StringAttribute{
+				Computed:    true,
+				Description: `The region slug where the branch is hosted.`,
 			},
 			"region_data": schema.SingleNestedAttribute{
 				Computed: true,

--- a/internal/provider/postgresbranch_data_source_sdk.go
+++ b/internal/provider/postgresbranch_data_source_sdk.go
@@ -41,6 +41,7 @@ func (r *PostgresBranchDataSourceModel) RefreshFromOperationsGetPostgresBranchRe
 		}
 		r.ParentBranch = types.StringPointerValue(resp.ParentBranch)
 		r.Ready = types.BoolValue(resp.Ready)
+		r.Region = types.StringValue(resp.Region)
 		r.RegionData = &tfTypes.GetPostgresBranchRegionData{}
 		r.RegionData.ID = types.StringValue(resp.RegionData.ID)
 		r.RegionData.MysqlSupported = types.BoolValue(resp.RegionData.MysqlSupported)

--- a/internal/provider/postgresbranch_resource.go
+++ b/internal/provider/postgresbranch_resource.go
@@ -156,9 +156,11 @@ func (r *PostgresBranchResource) Schema(ctx context.Context, req resource.Schema
 				Description: `Whether or not the branch is ready to serve queries`,
 			},
 			"region": schema.StringAttribute{
+				Computed: true,
 				Optional: true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplaceIfConfigured(),
+					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `The region to create the branch in. If not provided, the branch will be created in the default region for its database. Requires replacement if changed.`,
 			},

--- a/internal/provider/postgresbranch_resource.go
+++ b/internal/provider/postgresbranch_resource.go
@@ -81,7 +81,8 @@ func (r *PostgresBranchResource) Schema(ctx context.Context, req resource.Schema
 				},
 			},
 			"backup_id": schema.StringAttribute{
-				Optional: true,
+				Optional:  true,
+				WriteOnly: true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplaceIfConfigured(),
 				},
@@ -186,7 +187,8 @@ func (r *PostgresBranchResource) Schema(ctx context.Context, req resource.Schema
 				Description: `The number of replicas for the branch`,
 			},
 			"restore_point": schema.StringAttribute{
-				Optional: true,
+				Optional:  true,
+				WriteOnly: true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplaceIfConfigured(),
 				},
@@ -225,8 +227,21 @@ func (r *PostgresBranchResource) Configure(ctx context.Context, req resource.Con
 }
 
 func (r *PostgresBranchResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	var data *PostgresBranchResourceModel
-	var plan types.Object
+	var (
+		configData PostgresBranchResourceModel
+		data       PostgresBranchResourceModel
+		plan       types.Object
+	)
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &configData)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	opts := &PostgresBranchResourceModelOptions{
+		Config: &configData,
+	}
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
@@ -242,7 +257,7 @@ func (r *PostgresBranchResource) Create(ctx context.Context, req resource.Create
 		return
 	}
 
-	request, requestDiags := data.ToOperationsCreatePostgresBranchRequest(ctx)
+	request, requestDiags := data.ToOperationsCreatePostgresBranchRequest(ctx, opts)
 	resp.Diagnostics.Append(requestDiags...)
 
 	if resp.Diagnostics.HasError() {
@@ -279,7 +294,7 @@ func (r *PostgresBranchResource) Create(ctx context.Context, req resource.Create
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	request1, request1Diags := data.ToOperationsGetPostgresBranchRequest(ctx)
+	request1, request1Diags := data.ToOperationsGetPostgresBranchRequest(ctx, opts)
 	resp.Diagnostics.Append(request1Diags...)
 
 	if resp.Diagnostics.HasError() {
@@ -321,7 +336,7 @@ func (r *PostgresBranchResource) Create(ctx context.Context, req resource.Create
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	request2, request2Diags := data.ToOperationsApplyPostgresBranchTerraformChangesRequest(ctx)
+	request2, request2Diags := data.ToOperationsApplyPostgresBranchTerraformChangesRequest(ctx, opts)
 	resp.Diagnostics.Append(request2Diags...)
 
 	if resp.Diagnostics.HasError() {
@@ -361,7 +376,7 @@ func (r *PostgresBranchResource) Create(ctx context.Context, req resource.Create
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	request3, request3Diags := data.ToOperationsGetBranchChangeRequestRequest(ctx)
+	request3, request3Diags := data.ToOperationsGetBranchChangeRequestRequest(ctx, opts)
 	resp.Diagnostics.Append(request3Diags...)
 
 	if resp.Diagnostics.HasError() {
@@ -426,7 +441,7 @@ func (r *PostgresBranchResource) Read(ctx context.Context, req resource.ReadRequ
 		return
 	}
 
-	request, requestDiags := data.ToOperationsGetPostgresBranchRequest(ctx)
+	request, requestDiags := data.ToOperationsGetPostgresBranchRequest(ctx, nil)
 	resp.Diagnostics.Append(requestDiags...)
 
 	if resp.Diagnostics.HasError() {
@@ -467,8 +482,29 @@ func (r *PostgresBranchResource) Read(ctx context.Context, req resource.ReadRequ
 }
 
 func (r *PostgresBranchResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var data *PostgresBranchResourceModel
-	var plan types.Object
+	var (
+		configData PostgresBranchResourceModel
+		data       PostgresBranchResourceModel
+		plan       types.Object
+		stateData  PostgresBranchResourceModel
+	)
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &configData)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &stateData)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	opts := &PostgresBranchResourceModelOptions{
+		Config: &configData,
+		State:  &stateData,
+	}
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
@@ -480,7 +516,7 @@ func (r *PostgresBranchResource) Update(ctx context.Context, req resource.Update
 		return
 	}
 
-	request, requestDiags := data.ToOperationsUpdatePostgresBranchRequest(ctx)
+	request, requestDiags := data.ToOperationsUpdatePostgresBranchRequest(ctx, opts)
 	resp.Diagnostics.Append(requestDiags...)
 
 	if resp.Diagnostics.HasError() {
@@ -517,7 +553,7 @@ func (r *PostgresBranchResource) Update(ctx context.Context, req resource.Update
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	request1, request1Diags := data.ToOperationsApplyPostgresBranchTerraformChangesRequest(ctx)
+	request1, request1Diags := data.ToOperationsApplyPostgresBranchTerraformChangesRequest(ctx, opts)
 	resp.Diagnostics.Append(request1Diags...)
 
 	if resp.Diagnostics.HasError() {
@@ -557,7 +593,7 @@ func (r *PostgresBranchResource) Update(ctx context.Context, req resource.Update
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	request2, request2Diags := data.ToOperationsGetBranchChangeRequestRequest(ctx)
+	request2, request2Diags := data.ToOperationsGetBranchChangeRequestRequest(ctx, opts)
 	resp.Diagnostics.Append(request2Diags...)
 
 	if resp.Diagnostics.HasError() {
@@ -599,7 +635,7 @@ func (r *PostgresBranchResource) Update(ctx context.Context, req resource.Update
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	request3, request3Diags := data.ToOperationsGetPostgresBranchRequest(ctx)
+	request3, request3Diags := data.ToOperationsGetPostgresBranchRequest(ctx, opts)
 	resp.Diagnostics.Append(request3Diags...)
 
 	if resp.Diagnostics.HasError() {
@@ -659,7 +695,7 @@ func (r *PostgresBranchResource) Delete(ctx context.Context, req resource.Delete
 		return
 	}
 
-	request, requestDiags := data.ToOperationsDeletePostgresBranchRequest(ctx)
+	request, requestDiags := data.ToOperationsDeletePostgresBranchRequest(ctx, nil)
 	resp.Diagnostics.Append(requestDiags...)
 
 	if resp.Diagnostics.HasError() {

--- a/internal/provider/postgresbranch_resource_sdk.go
+++ b/internal/provider/postgresbranch_resource_sdk.go
@@ -91,6 +91,7 @@ func (r *PostgresBranchResourceModel) RefreshFromOperationsGetPostgresBranchResp
 		}
 		r.ParentBranch = types.StringPointerValue(resp.ParentBranch)
 		r.Ready = types.BoolValue(resp.Ready)
+		r.Region = types.StringValue(resp.Region)
 		r.RegionData = &tfTypes.GetPostgresBranchRegionData{}
 		r.RegionData.ID = types.StringValue(resp.RegionData.ID)
 		r.RegionData.MysqlSupported = types.BoolValue(resp.RegionData.MysqlSupported)

--- a/internal/provider/postgresbranch_resource_sdk.go
+++ b/internal/provider/postgresbranch_resource_sdk.go
@@ -10,6 +10,12 @@ import (
 	"github.com/planetscale/terraform-provider-planetscale/internal/sdk/models/operations"
 )
 
+// PostgresBranchResourceModelOptions enables patch sdk method construction.
+type PostgresBranchResourceModelOptions struct {
+	Config *PostgresBranchResourceModel
+	State  *PostgresBranchResourceModel
+}
+
 func (r *PostgresBranchResourceModel) RefreshFromOperationsApplyPostgresBranchTerraformChangesResponseBody(ctx context.Context, resp *operations.ApplyPostgresBranchTerraformChangesResponseBody) diag.Diagnostics {
 	var diags diag.Diagnostics
 
@@ -132,7 +138,7 @@ func (r *PostgresBranchResourceModel) RefreshFromOperationsUpdatePostgresBranchR
 	return diags
 }
 
-func (r *PostgresBranchResourceModel) ToOperationsApplyPostgresBranchTerraformChangesRequest(ctx context.Context) (*operations.ApplyPostgresBranchTerraformChangesRequest, diag.Diagnostics) {
+func (r *PostgresBranchResourceModel) ToOperationsApplyPostgresBranchTerraformChangesRequest(ctx context.Context, opts *PostgresBranchResourceModelOptions) (*operations.ApplyPostgresBranchTerraformChangesRequest, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
 	var organization string
@@ -144,7 +150,7 @@ func (r *PostgresBranchResourceModel) ToOperationsApplyPostgresBranchTerraformCh
 	var branch string
 	branch = r.ID.ValueString()
 
-	body, bodyDiags := r.ToOperationsApplyPostgresBranchTerraformChangesRequestBody(ctx)
+	body, bodyDiags := r.ToOperationsApplyPostgresBranchTerraformChangesRequestBody(ctx, opts)
 	diags.Append(bodyDiags...)
 
 	if diags.HasError() {
@@ -161,7 +167,7 @@ func (r *PostgresBranchResourceModel) ToOperationsApplyPostgresBranchTerraformCh
 	return &out, diags
 }
 
-func (r *PostgresBranchResourceModel) ToOperationsApplyPostgresBranchTerraformChangesRequestBody(ctx context.Context) (*operations.ApplyPostgresBranchTerraformChangesRequestBody, diag.Diagnostics) {
+func (r *PostgresBranchResourceModel) ToOperationsApplyPostgresBranchTerraformChangesRequestBody(ctx context.Context, opts *PostgresBranchResourceModelOptions) (*operations.ApplyPostgresBranchTerraformChangesRequestBody, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
 	clusterSize := new(string)
@@ -192,7 +198,7 @@ func (r *PostgresBranchResourceModel) ToOperationsApplyPostgresBranchTerraformCh
 	return &out, diags
 }
 
-func (r *PostgresBranchResourceModel) ToOperationsCreatePostgresBranchRequest(ctx context.Context) (*operations.CreatePostgresBranchRequest, diag.Diagnostics) {
+func (r *PostgresBranchResourceModel) ToOperationsCreatePostgresBranchRequest(ctx context.Context, opts *PostgresBranchResourceModelOptions) (*operations.CreatePostgresBranchRequest, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
 	var organization string
@@ -201,7 +207,7 @@ func (r *PostgresBranchResourceModel) ToOperationsCreatePostgresBranchRequest(ct
 	var database string
 	database = r.Database.ValueString()
 
-	body, bodyDiags := r.ToOperationsCreatePostgresBranchRequestBody(ctx)
+	body, bodyDiags := r.ToOperationsCreatePostgresBranchRequestBody(ctx, opts)
 	diags.Append(bodyDiags...)
 
 	if diags.HasError() {
@@ -217,7 +223,7 @@ func (r *PostgresBranchResourceModel) ToOperationsCreatePostgresBranchRequest(ct
 	return &out, diags
 }
 
-func (r *PostgresBranchResourceModel) ToOperationsCreatePostgresBranchRequestBody(ctx context.Context) (*operations.CreatePostgresBranchRequestBody, diag.Diagnostics) {
+func (r *PostgresBranchResourceModel) ToOperationsCreatePostgresBranchRequestBody(ctx context.Context, opts *PostgresBranchResourceModelOptions) (*operations.CreatePostgresBranchRequestBody, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
 	var name string
@@ -236,8 +242,8 @@ func (r *PostgresBranchResourceModel) ToOperationsCreatePostgresBranchRequestBod
 		parentBranch = nil
 	}
 	backupID := new(string)
-	if !r.BackupID.IsUnknown() && !r.BackupID.IsNull() {
-		*backupID = r.BackupID.ValueString()
+	if !opts.Config.BackupID.IsUnknown() && !opts.Config.BackupID.IsNull() {
+		*backupID = opts.Config.BackupID.ValueString()
 	} else {
 		backupID = nil
 	}
@@ -248,8 +254,8 @@ func (r *PostgresBranchResourceModel) ToOperationsCreatePostgresBranchRequestBod
 		region = nil
 	}
 	restorePoint := new(string)
-	if !r.RestorePoint.IsUnknown() && !r.RestorePoint.IsNull() {
-		*restorePoint = r.RestorePoint.ValueString()
+	if !opts.Config.RestorePoint.IsUnknown() && !opts.Config.RestorePoint.IsNull() {
+		*restorePoint = opts.Config.RestorePoint.ValueString()
 	} else {
 		restorePoint = nil
 	}
@@ -279,7 +285,7 @@ func (r *PostgresBranchResourceModel) ToOperationsCreatePostgresBranchRequestBod
 	return &out, diags
 }
 
-func (r *PostgresBranchResourceModel) ToOperationsDeletePostgresBranchRequest(ctx context.Context) (*operations.DeletePostgresBranchRequest, diag.Diagnostics) {
+func (r *PostgresBranchResourceModel) ToOperationsDeletePostgresBranchRequest(ctx context.Context, opts *PostgresBranchResourceModelOptions) (*operations.DeletePostgresBranchRequest, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
 	var organization string
@@ -307,7 +313,7 @@ func (r *PostgresBranchResourceModel) ToOperationsDeletePostgresBranchRequest(ct
 	return &out, diags
 }
 
-func (r *PostgresBranchResourceModel) ToOperationsGetBranchChangeRequestRequest(ctx context.Context) (*operations.GetBranchChangeRequestRequest, diag.Diagnostics) {
+func (r *PostgresBranchResourceModel) ToOperationsGetBranchChangeRequestRequest(ctx context.Context, opts *PostgresBranchResourceModelOptions) (*operations.GetBranchChangeRequestRequest, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
 	var organization string
@@ -332,7 +338,7 @@ func (r *PostgresBranchResourceModel) ToOperationsGetBranchChangeRequestRequest(
 	return &out, diags
 }
 
-func (r *PostgresBranchResourceModel) ToOperationsGetPostgresBranchRequest(ctx context.Context) (*operations.GetPostgresBranchRequest, diag.Diagnostics) {
+func (r *PostgresBranchResourceModel) ToOperationsGetPostgresBranchRequest(ctx context.Context, opts *PostgresBranchResourceModelOptions) (*operations.GetPostgresBranchRequest, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
 	var organization string
@@ -353,7 +359,7 @@ func (r *PostgresBranchResourceModel) ToOperationsGetPostgresBranchRequest(ctx c
 	return &out, diags
 }
 
-func (r *PostgresBranchResourceModel) ToOperationsUpdatePostgresBranchRequest(ctx context.Context) (*operations.UpdatePostgresBranchRequest, diag.Diagnostics) {
+func (r *PostgresBranchResourceModel) ToOperationsUpdatePostgresBranchRequest(ctx context.Context, opts *PostgresBranchResourceModelOptions) (*operations.UpdatePostgresBranchRequest, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
 	var organization string
@@ -365,7 +371,7 @@ func (r *PostgresBranchResourceModel) ToOperationsUpdatePostgresBranchRequest(ct
 	var branch string
 	branch = r.ID.ValueString()
 
-	body, bodyDiags := r.ToOperationsUpdatePostgresBranchRequestBody(ctx)
+	body, bodyDiags := r.ToOperationsUpdatePostgresBranchRequestBody(ctx, opts)
 	diags.Append(bodyDiags...)
 
 	if diags.HasError() {
@@ -382,7 +388,7 @@ func (r *PostgresBranchResourceModel) ToOperationsUpdatePostgresBranchRequest(ct
 	return &out, diags
 }
 
-func (r *PostgresBranchResourceModel) ToOperationsUpdatePostgresBranchRequestBody(ctx context.Context) (*operations.UpdatePostgresBranchRequestBody, diag.Diagnostics) {
+func (r *PostgresBranchResourceModel) ToOperationsUpdatePostgresBranchRequestBody(ctx context.Context, opts *PostgresBranchResourceModelOptions) (*operations.UpdatePostgresBranchRequestBody, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
 	name := new(string)

--- a/internal/provider/testdata/TestAccPostgresBranchResource_Lifecycle/main.tf
+++ b/internal/provider/testdata/TestAccPostgresBranchResource_Lifecycle/main.tf
@@ -23,6 +23,11 @@ variable "parameters" {
   default = null
 }
 
+data "planetscale_database_postgres" "test" {
+  organization = var.organization
+  id           = var.database_name
+}
+
 resource "planetscale_postgres_branch" "test" {
   organization       = var.organization
   database           = var.database_name
@@ -30,4 +35,5 @@ resource "planetscale_postgres_branch" "test" {
   cluster_size       = var.cluster_size
   deletion_protected = var.deletion_protected
   parameters         = var.parameters
+  region             = data.planetscale_database_postgres.test.region_data.slug
 }

--- a/internal/sdk/internal/hooks/postgres_branch_region_slug.go
+++ b/internal/sdk/internal/hooks/postgres_branch_region_slug.go
@@ -1,0 +1,64 @@
+package hooks
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"regexp"
+	"strconv"
+)
+
+var postgresBranchGetPathPattern = regexp.MustCompile(`^/v1/organizations/[^/]+/databases/[^/]+/branches/[^/]+$`)
+
+// PostgresBranchRegionSlugHook copies the nested region slug to a synthetic
+// top-level field on PostgreSQL branch GET responses. The generated Terraform
+// resource maps that field to the region attribute used by create and import.
+type PostgresBranchRegionSlugHook struct{}
+
+var _ sdkInitHook = (*PostgresBranchRegionSlugHook)(nil)
+
+func NewPostgresBranchRegionSlugHook() *PostgresBranchRegionSlugHook {
+	return &PostgresBranchRegionSlugHook{}
+}
+
+func (h *PostgresBranchRegionSlugHook) SDKInit(baseURL string, client HTTPClient) (string, HTTPClient) {
+	if client == nil {
+		return baseURL, client
+	}
+
+	return baseURL, &postgresBranchRegionSlugClient{client: client}
+}
+
+type postgresBranchRegionSlugClient struct {
+	client HTTPClient
+}
+
+func (c *postgresBranchRegionSlugClient) Do(req *http.Request) (*http.Response, error) {
+	res, err := c.client.Do(req)
+	if err != nil || res == nil || req == nil || req.URL == nil {
+		return res, err
+	}
+
+	if req.Method != http.MethodGet || res.StatusCode != http.StatusOK || !postgresBranchGetPathPattern.MatchString(req.URL.Path) {
+		return res, nil
+	}
+
+	body, readErr := io.ReadAll(res.Body)
+	drainAndClose(res.Body)
+	if readErr != nil {
+		return res, readErr
+	}
+
+	if rewritten, ok := hoistRegionSlug(body); ok {
+		body = rewritten
+	}
+
+	res.Body = io.NopCloser(bytes.NewReader(body))
+	res.ContentLength = int64(len(body))
+	if res.Header == nil {
+		res.Header = make(http.Header)
+	}
+	res.Header.Set("Content-Length", strconv.Itoa(len(body)))
+
+	return res, nil
+}

--- a/internal/sdk/internal/hooks/postgres_branch_region_slug_test.go
+++ b/internal/sdk/internal/hooks/postgres_branch_region_slug_test.go
@@ -1,0 +1,86 @@
+package hooks
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const postgresBranchGetURL = "https://api.planetscale.com/v1/organizations/org/databases/db/branches/br"
+
+func postgresBranchGetClient(status int, body string) HTTPClient {
+	hook := NewPostgresBranchRegionSlugHook()
+	_, wrappedClient := hook.SDKInit("https://api.planetscale.com", testHTTPClient(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: status,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Request:    req,
+		}, nil
+	}))
+	return wrappedClient
+}
+
+func TestPostgresBranchRegionSlugHookHoistsSlug(t *testing.T) {
+	client := postgresBranchGetClient(http.StatusOK, `{"id":"br","region":{"slug":"us-east","display_name":"US East"}}`)
+
+	req, err := http.NewRequest(http.MethodGet, postgresBranchGetURL, nil)
+	require.NoError(t, err)
+
+	res, err := client.Do(req)
+	require.NoError(t, err)
+	bodyBytes, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+
+	require.JSONEq(t, `{
+		"id": "br",
+		"region": {"slug": "us-east", "display_name": "US East"},
+		"region_slug": "us-east"
+	}`, string(bodyBytes))
+	require.Equal(t, int64(len(bodyBytes)), res.ContentLength)
+}
+
+func TestPostgresBranchRegionSlugHookPassesThroughUnexpectedBody(t *testing.T) {
+	responseBody := `{"id":"br"}`
+	client := postgresBranchGetClient(http.StatusOK, responseBody)
+
+	req, err := http.NewRequest(http.MethodGet, postgresBranchGetURL, nil)
+	require.NoError(t, err)
+	res, err := client.Do(req)
+	require.NoError(t, err)
+	bodyBytes, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+
+	require.Equal(t, responseBody, string(bodyBytes))
+}
+
+func TestPostgresBranchRegionSlugHookIgnoresOtherPaths(t *testing.T) {
+	responseBody := `{"region":{"slug":"us-east"}}`
+	client := postgresBranchGetClient(http.StatusOK, responseBody)
+
+	req, err := http.NewRequest(http.MethodGet, postgresBranchGetURL+"/backups", nil)
+	require.NoError(t, err)
+	res, err := client.Do(req)
+	require.NoError(t, err)
+	bodyBytes, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+
+	require.Equal(t, responseBody, string(bodyBytes))
+}
+
+func TestPostgresBranchRegionSlugHookIgnoresNon200(t *testing.T) {
+	responseBody := `{"code":"not_found"}`
+	client := postgresBranchGetClient(http.StatusNotFound, responseBody)
+
+	req, err := http.NewRequest(http.MethodGet, postgresBranchGetURL, nil)
+	require.NoError(t, err)
+	res, err := client.Do(req)
+	require.NoError(t, err)
+	bodyBytes, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+
+	require.Equal(t, responseBody, string(bodyBytes))
+}

--- a/internal/sdk/internal/hooks/registration.go
+++ b/internal/sdk/internal/hooks/registration.go
@@ -12,6 +12,7 @@ func initHooks(h *Hooks) {
 	customSecurityHook := &CustomSecurityHook{}
 
 	h.registerSDKInitHook(NewPostgresBranchNoContentSkipHook())
+	h.registerSDKInitHook(NewPostgresBranchRegionSlugHook())
 	h.registerSDKInitHook(NewPostgresBouncerNoContentSkipHook())
 	h.registerSDKInitHook(NewVitessBranchNoContentSkipHook())
 	h.registerSDKInitHook(NewReadOnlyReplicaRegionSlugHook())

--- a/internal/sdk/models/operations/getpostgresbranch.go
+++ b/internal/sdk/models/operations/getpostgresbranch.go
@@ -139,6 +139,8 @@ type GetPostgresBranchResponseBody struct {
 	RegionData GetPostgresBranchRegionData `json:"region"`
 	// The name of the parent branch from which the branch was created
 	ParentBranch *string `json:"parent_branch"`
+	// The region slug where the branch is hosted.
+	Region string `json:"region_slug"`
 	// The number of replicas for the branch
 	Replicas *int64 `json:"replicas,omitzero"`
 	// Postgres parameter overrides, nested by namespace (pgconf, pgbouncer, patroni), e.g. { pgconf = { max_connections = "200" } }. Omitted parameters are reset to their defaults.
@@ -231,6 +233,13 @@ func (g *GetPostgresBranchResponseBody) GetParentBranch() *string {
 		return nil
 	}
 	return g.ParentBranch
+}
+
+func (g *GetPostgresBranchResponseBody) GetRegion() string {
+	if g == nil {
+		return ""
+	}
+	return g.Region
 }
 
 func (g *GetPostgresBranchResponseBody) GetReplicas() *int64 {

--- a/internal/sdk/planetscale.go
+++ b/internal/sdk/planetscale.go
@@ -160,9 +160,9 @@ func WithTimeout(timeout time.Duration) SDKOption {
 // New creates a new instance of the SDK with the provided options
 func New(opts ...SDKOption) *PlanetScale {
 	sdk := &PlanetScale{
-		SDKVersion: "1.8.0",
+		SDKVersion: "1.11.0",
 		sdkConfiguration: config.SDKConfiguration{
-			UserAgent:  "speakeasy-sdk/terraform 1.8.0 2.928.0 v1 github.com/planetscale/terraform-provider-planetscale/internal/sdk",
+			UserAgent:  "speakeasy-sdk/terraform 1.11.0 2.928.0 v1 github.com/planetscale/terraform-provider-planetscale/internal/sdk",
 			ServerList: ServerList,
 		},
 		hooks: hooks.New(),

--- a/schemas/out.openapi.yaml
+++ b/schemas/out.openapi.yaml
@@ -5780,6 +5780,10 @@ paths:
                     type: string
                     description: The name of the parent branch from which the branch was created
                     nullable: true
+                  region_slug:
+                    type: string
+                    x-speakeasy-name-override: region
+                    description: The region slug where the branch is hosted.
                   replicas:
                     type: integer
                     description: The number of replicas for the branch
@@ -5833,6 +5837,7 @@ paths:
                   - region
                   - parent_branch
                   - vtgate_options
+                  - region_slug
         "401":
           description: Unauthorized
         "403":

--- a/schemas/out.openapi.yaml
+++ b/schemas/out.openapi.yaml
@@ -5501,12 +5501,14 @@ paths:
                 backup_id:
                   type: string
                   description: If provided, restores the backup's schema and data to the new branch. Must have `restore_production_branch_backup(s)` or `restore_backup(s)` access to do this.
+                  x-speakeasy-terraform-write-only: true
                 region:
                   type: string
                   description: The region to create the branch in. If not provided, the branch will be created in the default region for its database.
                 restore_point:
                   type: string
                   description: Restore from a point-in-time recovery timestamp (e.g. 2023-01-01T00:00:00Z). Available only for PostgreSQL databases.
+                  x-speakeasy-terraform-write-only: true
                 cluster_size:
                   type: string
                   description: "The database cluster size. Required if a backup_id is provided (unless keyspace_cluster_sizes covers every keyspace), optional otherwise. Options: PS_10, PS_20, PS_40, ..., PS_2800"

--- a/schemas/overlay-terraform-postgres-branch.yaml
+++ b/schemas/overlay-terraform-postgres-branch.yaml
@@ -16,6 +16,14 @@ actions:
     description: Remove seed_data (Vitess-only field)
     remove: true
 
+  - target: $.paths['/organizations/{organization}/databases/{database}/branches#postgres'].post.requestBody.content['application/json'].schema.properties['backup_id','restore_point']
+    description: >-
+      Treat backup restore inputs as create-only values. Terraform passes them
+      to Create but does not persist them in plan or state, so later reads and
+      imports do not attempt to reconcile restore provenance.
+    update:
+      x-speakeasy-terraform-write-only: true
+
   - target: $.paths['/organizations/{organization}/databases/{database}/branches#postgres'].post.requestBody.content['application/json'].schema.properties.cluster_size
     update:
       x-speakeasy-plan-validators: ClusterSizeValidator

--- a/schemas/overlay-terraform-postgres-branch.yaml
+++ b/schemas/overlay-terraform-postgres-branch.yaml
@@ -64,6 +64,19 @@ actions:
             - condition: $statusCode == 200
             - condition: $response.body#/state == "ready"
 
+  - target: $.paths['/organizations/{organization}/databases/{database}/branches/{branch}#postgres'].get.responses['200'].content['application/json'].schema.properties
+    description: >-
+      Add a synthetic region slug populated from the nested API region object
+      by a client hook so reads and imports refresh the configured region.
+    update:
+      region_slug:
+        type: string
+        x-speakeasy-name-override: region
+        description: The region slug where the branch is hosted.
+  - target: $.paths['/organizations/{organization}/databases/{database}/branches/{branch}#postgres'].get.responses['200'].content['application/json'].schema.required
+    update:
+      - region_slug
+
 
   - target: $.paths['/organizations/{organization}/databases/{database}/branches/{branch}#postgres'].get.responses['200'].content['application/json'].schema.properties
     description: Add Postgres response fields


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Terraform currently proposes replacing an imported Postgres branch when its configuration includes a region or backup restore inputs. This change refreshes the region during reads and treats `backup_id` and `restore_point` as creation-only values. The provider now targets Terraform 1.11 to support this behavior.

Closes #335
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-81c84aca-1fd3-4ad4-bca5-5a0508ca344e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-81c84aca-1fd3-4ad4-bca5-5a0508ca344e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

